### PR TITLE
Map window data

### DIFF
--- a/code/include/HumanGameView.hpp
+++ b/code/include/HumanGameView.hpp
@@ -51,14 +51,17 @@ private:
   // Takes a coordinate pair (map_coords) denoting a location on the game map
   // and returns a coordinate pair (window_coords) denoting where the top-left
   // point of that map location is in the window, given current map and window
-  // sizes.  Depends on the results of the last run of calculateMapWindowData().
-  void mapToWindow(const sf::Vector2u& map_coords, sf::Vector2u& window_coords); 
+  // sizes.  Depends on the results of the last run of
+  // calculateMapWindowData().  Returns true if the transformation was
+  // successful, false otherwise.
+  bool mapToWindow(const sf::Vector2u& map_coords, sf::Vector2u& window_coords); 
 
   // Takes a coordinate pair (window_coords) denoting a location in the window
   // and returns a coordinate pair (map_coords) denoting where that location
   // is on the map, given current map and window sizes.  Depends on the results
-  // of the last run of calculateMapWindowData().
-  void windowToMap(const sf::Vector2u& window_coords, sf::Vector2u& map_coords);
+  // of the last run of calculateMapWindowData().  Returns true if the
+  // transformation was successful, false otherwise.
+  bool windowToMap(const sf::Vector2u& window_coords, sf::Vector2u& map_coords);
 
   // Location of the top-left corner of the map in window coordinates
   sf::Vector2u map_tl_wcoords;

--- a/code/include/HumanGameView.hpp
+++ b/code/include/HumanGameView.hpp
@@ -34,6 +34,21 @@ public:
 
 private:
 
+  // Calculates where the top-left corner of the map is in window coordinates
+  // (map_tl_wcoords) and what the map tile size is in pixels (map_tile_size).
+  void calculateMapWindowData();
+
+  // Takes a coordinate pair (map_coords) denoting a location on the game map
+  // and returns a coordinate pair (window_coords) denoting where that location
+  // is in the window, given current map and window sizes.
+  void mapToWindow(const sf::Vector2u& map_coords, sf::Vector2u& window_coords); 
+
+  // Location of the top-left corner of the map in window coordinates
+  sf::Vector2u map_tl_wcoords;
+
+  // Side length of map tiles in pixels
+  unsigned int map_tile_size;
+
   // boolean that represents if a menu is asking for input
   // so gameview knows whether to read for text input
   // or game commands

--- a/code/include/HumanGameView.hpp
+++ b/code/include/HumanGameView.hpp
@@ -50,8 +50,15 @@ private:
 
   // Takes a coordinate pair (map_coords) denoting a location on the game map
   // and returns a coordinate pair (window_coords) denoting where that location
-  // is in the window, given current map and window sizes.
+  // is in the window, given current map and window sizes.  Depends on the
+  // results of the last run of calculateMapWindowData().
   void mapToWindow(const sf::Vector2u& map_coords, sf::Vector2u& window_coords); 
+
+  // Takes a coordinate pair (window_coords) denoting a location in the window
+  // and returns a coordinate pair (map_coords) denoting where that location
+  // is on the map, given current map and window sizes.  Depends on the results
+  // of the last run of calculateMapWindowData().
+  void windowToMap(const sf::Vector2u& window_coords, sf::Vector2u& map_coords);
 
   // Location of the top-left corner of the map in window coordinates
   sf::Vector2u map_tl_wcoords;

--- a/code/include/HumanGameView.hpp
+++ b/code/include/HumanGameView.hpp
@@ -49,9 +49,9 @@ private:
   void calculateMapWindowData();
 
   // Takes a coordinate pair (map_coords) denoting a location on the game map
-  // and returns a coordinate pair (window_coords) denoting where that location
-  // is in the window, given current map and window sizes.  Depends on the
-  // results of the last run of calculateMapWindowData().
+  // and returns a coordinate pair (window_coords) denoting where the top-left
+  // point of that map location is in the window, given current map and window
+  // sizes.  Depends on the results of the last run of calculateMapWindowData().
   void mapToWindow(const sf::Vector2u& map_coords, sf::Vector2u& window_coords); 
 
   // Takes a coordinate pair (window_coords) denoting a location in the window

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -193,3 +193,49 @@ void HumanGameView::drawUI() {
 		elem->draw(App);
 	}
 }
+
+void HumanGameView::calculateMapWindowData()
+{
+  // We need to know the aspect ratio of the map (here we're assuming maps are
+  // always rectangular) to calculate where the left edge of the map should
+  // start
+  double map_aspect_ratio =
+    static_cast<double>(tempMap.get_map_size_x()) /
+    static_cast<double>(tempMap.get_map_size_y());
+
+  // If the map's aspect ratio is less than the window's, then there will be
+  // sidebars.  If the two aspect ratios are equal, the map will fit perfectly
+  // in the window and there will be no sidebars or horizontal bars.  If the
+  // map's aspect ratio is greater than the window's, there will be horizontal
+  // bars.
+
+  // For now assume the top-left map coordinate is 0,0.  This will be updated
+  // later if it isn't the case
+  map_tl_wcoords.x = 0;
+  map_tl_wcoords.y = 0;
+
+  // The ratio between the two aspect ratios
+  double ar_ratio = map_aspect_ratio / aspectRatio;
+
+  if (ar_ratio > 1.0)
+  {
+    map_tl_wcoords.x = 0.0;
+    map_tl_wcoords.y =
+      static_cast<unsigned int>(
+	static_cast<double>(currentRes.y) / ar_ratio / 2.0);
+  }
+  else if (ar_ratio < 1.0)
+  {
+    map_tl_wcoords.x =
+      static_cast<unsigned int>(
+	static_cast<double>(currentRes.x) / ar_ratio / 2.0);
+    map_tl_wcoords.y = 0.0;
+  }
+
+  std::cout << map_tl_wcoords.x << " " << map_tl_wcoords.y << "\n";
+}
+
+void HumanGameView::mapToWindow(const sf::Vector2u& map_coords,
+				sf::Vector2u&       window_coords)
+{
+}

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -312,13 +312,36 @@ void HumanGameView::calculateMapWindowData()
   }
 }
 
-void HumanGameView::mapToWindow(const sf::Vector2u& map_coords,
+bool HumanGameView::mapToWindow(const sf::Vector2u& map_coords,
 				sf::Vector2u&       window_coords)
 {
-  
+  // No conversion possible if input isn't on the map
+  if (map_coords.x > tempMap.get_map_size_x() - 1 ||
+      map_coords.y > tempMap.get_map_size_y() - 1)
+  {
+    return false;
+  }
+
+  window_coords.x = map_coords.x * map_tile_size + map_tl_wcoords.x;
+  window_coords.y = map_coords.y * map_tile_size + map_tl_wcoords.y;
+
+  return true;
 }
 
-void HumanGameView::windowToMap(const sf::Vector2u& window_coords,
+bool HumanGameView::windowToMap(const sf::Vector2u& window_coords,
 				sf::Vector2u&       map_coords)
 {
+  sf::Vector2u window_size = App->getSize();
+
+  // No conversion possible if input isn't in the window
+  if (window_coords.x > window_size.x - 1 ||
+      window_coords.y > window_size.y - 1)
+  {
+    return false;
+  }
+
+  map_coords.x = (window_coords.x - map_tl_wcoords.x) / map_tile_size;
+  map_coords.y = (window_coords.y - map_tl_wcoords.y) / map_tile_size;
+
+  return true;
 }

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -3,7 +3,9 @@
 
 HumanGameView::HumanGameView(GameLogic* game_logic, sf::RenderWindow* App) :
   GameView(game_logic),
-  App(App)  
+  map_tl_wcoords(0, 0),
+  map_tile_size(0),
+  App(App)
 {
 	if (!texture.loadFromFile("./data/sprites.png")) {
 		std::cout << "ERROR TEXTURE" << std::endl;
@@ -47,7 +49,8 @@ void HumanGameView::update(const sf::Time& delta_t)
   readInputs(delta_t);
   
   App->clear(sf::Color::Black);
-  
+
+  calculateMapWindowData();
   drawMap();
   drawActors();
   drawUI();
@@ -301,7 +304,8 @@ void HumanGameView::calculateMapWindowData()
     map_tl_wcoords.x = 0;
     map_tl_wcoords.y = 0;
 
-    // Update the map tile size
+    // Update the map tile size; this is the same as the ar_ratio < 1.0 case
+    // above
     map_tile_size = static_cast<unsigned int>(
       static_cast<double>(window_size.y) /
       static_cast<double>(tempMap.get_map_size_y()));
@@ -310,5 +314,11 @@ void HumanGameView::calculateMapWindowData()
 
 void HumanGameView::mapToWindow(const sf::Vector2u& map_coords,
 				sf::Vector2u&       window_coords)
+{
+  
+}
+
+void HumanGameView::windowToMap(const sf::Vector2u& window_coords,
+				sf::Vector2u&       map_coords)
 {
 }

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -39,7 +39,7 @@ void HumanGameView::update(const sf::Time& delta_t)
   drawMap();
   drawActors();
   drawUI();
-  
+
   // Can use App to draw in the game window
   
   App->display();
@@ -203,6 +203,14 @@ void HumanGameView::calculateMapWindowData()
     static_cast<double>(tempMap.get_map_size_x()) /
     static_cast<double>(tempMap.get_map_size_y());
 
+  // Get the current size of the window
+  sf::Vector2u window_size = App->getSize();
+
+  // What's the aspect ratio of the window?
+  double window_aspect_ratio =
+    static_cast<double>(window_size.x) / static_cast<double>(window_size.y);
+
+
   // If the map's aspect ratio is less than the window's, then there will be
   // sidebars.  If the two aspect ratios are equal, the map will fit perfectly
   // in the window and there will be no sidebars or horizontal bars.  If the
@@ -215,24 +223,20 @@ void HumanGameView::calculateMapWindowData()
   map_tl_wcoords.y = 0;
 
   // The ratio between the two aspect ratios
-  double ar_ratio = map_aspect_ratio / aspectRatio;
+  double ar_ratio = map_aspect_ratio / window_aspect_ratio;
 
   if (ar_ratio > 1.0)
   {
     map_tl_wcoords.x = 0.0;
     map_tl_wcoords.y =
-      static_cast<unsigned int>(
-	static_cast<double>(currentRes.y) / ar_ratio / 2.0);
+      (currentRes.y - (static_cast<double>(currentRes.y) / ar_ratio)) / 2.0;
   }
   else if (ar_ratio < 1.0)
   {
     map_tl_wcoords.x =
-      static_cast<unsigned int>(
-	static_cast<double>(currentRes.x) / ar_ratio / 2.0);
+      (currentRes.x - (static_cast<double>(currentRes.x) * ar_ratio)) / 2.0;;
     map_tl_wcoords.y = 0.0;
   }
-
-  std::cout << map_tl_wcoords.x << " " << map_tl_wcoords.y << "\n";
 }
 
 void HumanGameView::mapToWindow(const sf::Vector2u& map_coords,

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -230,12 +230,20 @@ void HumanGameView::calculateMapWindowData()
     map_tl_wcoords.x = 0.0;
     map_tl_wcoords.y =
       (currentRes.y - (static_cast<double>(currentRes.y) / ar_ratio)) / 2.0;
+
+    map_tile_size = static_cast<unsigned int>(
+      static_cast<double>(window_size.x) /
+      static_cast<double>(tempMap.get_map_size_x()));
   }
   else if (ar_ratio < 1.0)
   {
     map_tl_wcoords.x =
       (currentRes.x - (static_cast<double>(currentRes.x) * ar_ratio)) / 2.0;;
     map_tl_wcoords.y = 0.0;
+
+    map_tile_size = static_cast<unsigned int>(
+      static_cast<double>(window_size.y) /
+      static_cast<double>(tempMap.get_map_size_y()));
   }
 }
 

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -51,6 +51,7 @@ void HumanGameView::update(const sf::Time& delta_t)
   App->clear(sf::Color::Black);
 
   calculateMapWindowData();
+
   drawMap();
   drawActors();
   drawUI();
@@ -58,7 +59,6 @@ void HumanGameView::update(const sf::Time& delta_t)
   // Can use App to draw in the game window
   
   App->display();
-  
 }
 
 // reads the inputs from the window and act on them accordingly
@@ -333,9 +333,11 @@ bool HumanGameView::windowToMap(const sf::Vector2u& window_coords,
 {
   sf::Vector2u window_size = App->getSize();
 
-  // No conversion possible if input isn't in the window
-  if (window_coords.x > window_size.x - 1 ||
-      window_coords.y > window_size.y - 1)
+  // No conversion possible if input isn't over the map
+  if (window_coords.x < map_tl_wcoords.x ||
+      window_coords.y < map_tl_wcoords.y ||
+      window_coords.x > window_size.x - map_tl_wcoords.x ||
+      window_coords.y > window_size.y - map_tl_wcoords.y)
   {
     return false;
   }

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -217,30 +217,47 @@ void HumanGameView::calculateMapWindowData()
   // map's aspect ratio is greater than the window's, there will be horizontal
   // bars.
 
-  // For now assume the top-left map coordinate is 0,0.  This will be updated
-  // later if it isn't the case
-  map_tl_wcoords.x = 0;
-  map_tl_wcoords.y = 0;
 
   // The ratio between the two aspect ratios
   double ar_ratio = map_aspect_ratio / window_aspect_ratio;
 
   if (ar_ratio > 1.0)
   {
+    // The constraining window dimension is the horizontal dimension
+
+    // Update map top-left location
     map_tl_wcoords.x = 0.0;
     map_tl_wcoords.y =
       (currentRes.y - (static_cast<double>(currentRes.y) / ar_ratio)) / 2.0;
 
+    // Update map tile size
     map_tile_size = static_cast<unsigned int>(
       static_cast<double>(window_size.x) /
       static_cast<double>(tempMap.get_map_size_x()));
   }
   else if (ar_ratio < 1.0)
   {
+    // The constraining window dimension is the vertical dimension
+
+    // Update the top-left location
     map_tl_wcoords.x =
-      (currentRes.x - (static_cast<double>(currentRes.x) * ar_ratio)) / 2.0;;
+      (currentRes.x - (static_cast<double>(currentRes.x) * ar_ratio)) / 2.0;
     map_tl_wcoords.y = 0.0;
 
+    // Update the map tile size
+    map_tile_size = static_cast<unsigned int>(
+      static_cast<double>(window_size.y) /
+      static_cast<double>(tempMap.get_map_size_y()));
+  }
+  else
+  {
+    // The window dimensions perfectly match the map dimensions.
+
+    // Update the top-left location
+    map_tl_wcoords.x = 0;
+    map_tl_wcoords.y = 0;
+
+    // Update the map tile size
     map_tile_size = static_cast<unsigned int>(
       static_cast<double>(window_size.y) /
       static_cast<double>(tempMap.get_map_size_y()));


### PR DESCRIPTION
Adds some functionality to the human game view to make it easy to translate from map to window coordinates, and from window to map coordinates.  The calculateMapWindowData() function runs each frame and calculates where the top-left corner of the map should be placed in window coordinates, and stores this in a new 'map_tl_wcoords' vector.  It also calculates how big map tiles should be drawn, and stores this in a new 'map_tile_size' data member.

Two helper functions, mapToWindow() and windowToMap(), were also added.  mapToWindow accepts a vector position on the map (in map coordinates) and returns where that position is in the window (in window coordinates).  windowToMap() accepts a vector position in the window (in window coordinates) and returns where that position would be on the map (in map coordinates).
