### PR TITLE
Take a look and see what you think. The map and the sprites are re-scale...

### DIFF
--- a/code/include/HumanGameView.hpp
+++ b/code/include/HumanGameView.hpp
@@ -100,6 +100,9 @@ private:
   
   // the dialogue box
   UITextInput *test;
+
+  // scale sprite to appropriate size when resizing window
+  float spriteScale;
   
   // temp ints for storing transaction event data
   ActorId tc_shipid;

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -52,6 +52,9 @@ void HumanGameView::update(const sf::Time& delta_t)
 
   calculateMapWindowData();
 
+  // each sprite is 25x25
+  spriteScale = map_tile_size / 25.0;
+
   drawMap();
   drawActors();
   drawUI();
@@ -142,19 +145,24 @@ void HumanGameView::readInputs(const sf::Time& delta_t) {
 
 // draws the map
 void HumanGameView::drawMap() {
-	int x_position = 0;
-	int y_position = 0;
+	int x_position = map_tl_wcoords.x;
+	int y_position = map_tl_wcoords.y;
+	
 	// these things never change as of right now so they could be created as
 	// members of the class...
-	int tile_size = tempMap.get_tile_size();
 	int map_size_x = tempMap.get_map_size_x();
 	int map_size_y = tempMap.get_map_size_y();
+	
 	sf::Sprite land_sprite;
 	sf::Sprite water_sprite;
 	land_sprite.setTexture(texture);
 	water_sprite.setTexture(texture);
+	
 	land_sprite.setTextureRect(sf::IntRect(106,50,25,25));
 	water_sprite.setTextureRect(sf::IntRect(106,25,25,25));
+	
+	land_sprite.scale(spriteScale,spriteScale);
+	water_sprite.scale(spriteScale,spriteScale);
 	
 	for (int y = 0; y < map_size_y; y++) {
         	for (int x = 0; x < map_size_x; x++) {
@@ -166,20 +174,21 @@ void HumanGameView::drawMap() {
                 		water_sprite.setPosition(sf::Vector2f(x_position, y_position));
                 		App->draw(water_sprite);
             		}
-            		x_position += tile_size;
+            		x_position += map_tile_size;
         	}
-        	x_position = 0;
-        	y_position += tile_size;
+        	x_position = map_tl_wcoords.x;
+        	y_position += map_tile_size;
     	}
 }
 
 // draws the actors
 void HumanGameView::drawActors() {
-	int tileSize = tempMap.get_tile_size();
-	
 	sf::Sprite port_sprite;
 	port_sprite.setTexture(texture);
 	port_sprite.setTextureRect(sf::IntRect(105,0,25,25));
+
+	port_sprite.scale(spriteScale,spriteScale);
+
 	std::map<ActorId, Port*> ports = getGameLogic()->getPortsList();
 	for (std::map<ActorId, Port*>::iterator i = ports.begin(); i != ports.end(); i++) {
 		if(i->second->isBuyPort()){
@@ -188,15 +197,17 @@ void HumanGameView::drawActors() {
 		else {
 			port_sprite.setColor(sf::Color::Yellow);
 		}
-		port_sprite.setPosition(sf::Vector2f(i->second->getPositionX() * tileSize, i->second->getPositionY() * tileSize));
+		port_sprite.setPosition(sf::Vector2f(i->second->getPositionX() * map_tile_size + map_tl_wcoords.x, i->second->getPositionY() * map_tile_size + map_tl_wcoords.y));
 		App->draw(port_sprite);
 	}
 
 	sf::Sprite ship_sprite;
 	ship_sprite.setTexture(texture);
 	ship_sprite.setTextureRect(sf::IntRect(0,0,25,25));
+
+	ship_sprite.scale(spriteScale,spriteScale);
 	const Ship* ship = getGameLogic()->getShip();
-	ship_sprite.setPosition(sf::Vector2f(ship->getPositionX() * tileSize, ship->getPositionY() * tileSize));
+	ship_sprite.setPosition(sf::Vector2f(ship->getPositionX() * map_tile_size + map_tl_wcoords.x, ship->getPositionY() * map_tile_size + map_tl_wcoords.y));
 	App->draw(ship_sprite);
 }
   


### PR DESCRIPTION
...d appropriately depending on the window resizing. However, the map remains centered if ONLY the window is vertically resized or ONLY if the window is horizontally resized. When the window is resized in both directions, the map is almost but not quite centered. If there are any obvious errs that I've made, let me know, otherwise I can show everyone what it's doing when we meet on Sunday.

I'm creating a pull request for this in case anyone wanted to test this branch for themselves. I think you would be able to do that without a pull request but I wasn't positive.
