### PR TITLE
Port ship ui display

### DIFF
--- a/code/include/HumanGameView.hpp
+++ b/code/include/HumanGameView.hpp
@@ -119,11 +119,6 @@ private:
   int tc_shipgold;
   int tc_shiprum;
   int tc_portrum;
-
-  // UI data on the ports.  Right now display of the port UI data doesn't
-  // support changes in the number of ports at runtime, which is okay because
-  // neither do some other systems in the game
-  std::map<ActorId, UIPortData*> port_ui_data;
 };
 
 inline unsigned int HumanGameView::getMapTileSize() const

--- a/code/include/HumanGameView.hpp
+++ b/code/include/HumanGameView.hpp
@@ -32,6 +32,8 @@ public:
   virtual void update(const sf::Time& delta_t);
   
   void readInputs(const sf::Time& delta_t);
+
+  void updateUI();
   
   void drawMap();
   
@@ -42,8 +44,6 @@ public:
   void transactionFailEventHandler(const EventInterface& event);
   void transactionSuccessEventHandler(const EventInterface& event);
   void transactionStartEventHandler(const EventInterface& event);
-
-
 
 private:
 

--- a/code/include/HumanGameView.hpp
+++ b/code/include/HumanGameView.hpp
@@ -60,6 +60,8 @@ public:
   // transformation was successful, false otherwise.
   bool windowToMap(const sf::Vector2f& window_coords, sf::Vector2f& map_coords);
 
+  unsigned int getMapTileSize() const;
+
 private:
 
   // Calculates where the top-left corner of the map is in window coordinates
@@ -123,5 +125,10 @@ private:
   // neither do some other systems in the game
   std::map<ActorId, UIPortData*> port_ui_data;
 };
+
+inline unsigned int HumanGameView::getMapTileSize() const
+{
+  return map_tile_size;
+}
 
 #endif

--- a/code/include/HumanGameView.hpp
+++ b/code/include/HumanGameView.hpp
@@ -3,13 +3,15 @@
 
 #include <SFML/Graphics.hpp>
 #include <SFML/System/Time.hpp>
+#include <map>
 #include <vector>
 
+#include "ActorId.hpp"
 #include "GameLogic.hpp"
 #include "GameView.hpp"
 #include "UIElement.hpp"
 #include "UITextInput.hpp"
-#include "UITextField.hpp"
+#include "UIPortData.hpp"
 #include "Map.hpp"
 #include "ShipMoveCmdEvent.hpp"
 #include "TransactionCheckEvent.hpp"
@@ -55,14 +57,14 @@ private:
   // sizes.  Depends on the results of the last run of
   // calculateMapWindowData().  Returns true if the transformation was
   // successful, false otherwise.
-  bool mapToWindow(const sf::Vector2u& map_coords, sf::Vector2u& window_coords); 
+  bool mapToWindow(const sf::Vector2f& map_coords, sf::Vector2f& window_coords); 
 
   // Takes a coordinate pair (window_coords) denoting a location in the window
   // and returns a coordinate pair (map_coords) denoting where that location
   // is on the map, given current map and window sizes.  Depends on the results
   // of the last run of calculateMapWindowData().  Returns true if the
   // transformation was successful, false otherwise.
-  bool windowToMap(const sf::Vector2u& window_coords, sf::Vector2u& map_coords);
+  bool windowToMap(const sf::Vector2f& window_coords, sf::Vector2f& map_coords);
 
   // Location of the top-left corner of the map in window coordinates
   sf::Vector2u map_tl_wcoords;
@@ -116,13 +118,10 @@ private:
   int tc_shiprum;
   int tc_portrum;
 
-  // UI data on the ship and ports
-
-  // Displays ship UI data
-  UITextField ship_ui_data;
-
-  // Displays port UI data
-  std::vector<UITextField*> port_ui_data;
+  // UI data on the ports.  Right now display of the port UI data doesn't
+  // support changes in the number of ports at runtime, which is okay because
+  // neither do some other systems in the game
+  std::map<ActorId, UIPortData*> port_ui_data;
 };
 
 #endif

--- a/code/include/HumanGameView.hpp
+++ b/code/include/HumanGameView.hpp
@@ -45,12 +45,6 @@ public:
   void transactionSuccessEventHandler(const EventInterface& event);
   void transactionStartEventHandler(const EventInterface& event);
 
-private:
-
-  // Calculates where the top-left corner of the map is in window coordinates
-  // (map_tl_wcoords) and what the map tile size is in pixels (map_tile_size).
-  void calculateMapWindowData();
-
   // Takes a coordinate pair (map_coords) denoting a location on the game map
   // and returns a coordinate pair (window_coords) denoting where the top-left
   // point of that map location is in the window, given current map and window
@@ -65,6 +59,12 @@ private:
   // of the last run of calculateMapWindowData().  Returns true if the
   // transformation was successful, false otherwise.
   bool windowToMap(const sf::Vector2f& window_coords, sf::Vector2f& map_coords);
+
+private:
+
+  // Calculates where the top-left corner of the map is in window coordinates
+  // (map_tl_wcoords) and what the map tile size is in pixels (map_tile_size).
+  void calculateMapWindowData();
 
   // Location of the top-left corner of the map in window coordinates
   sf::Vector2u map_tl_wcoords;

--- a/code/include/HumanGameView.hpp
+++ b/code/include/HumanGameView.hpp
@@ -9,6 +9,7 @@
 #include "GameView.hpp"
 #include "UIElement.hpp"
 #include "UITextInput.hpp"
+#include "UITextField.hpp"
 #include "Map.hpp"
 #include "ShipMoveCmdEvent.hpp"
 #include "TransactionCheckEvent.hpp"
@@ -114,6 +115,14 @@ private:
   int tc_shipgold;
   int tc_shiprum;
   int tc_portrum;
+
+  // UI data on the ship and ports
+
+  // Displays ship UI data
+  UITextField ship_ui_data;
+
+  // Displays port UI data
+  std::vector<UITextField*> port_ui_data;
 };
 
 #endif

--- a/code/include/Port.hpp
+++ b/code/include/Port.hpp
@@ -31,6 +31,8 @@ public:
 
   void setRumRate(double rum_rate);
 
+  double getRumPrice() const;
+
   bool const isBuyPort() const;
 
   // Returns the name of this port
@@ -80,6 +82,11 @@ inline double Port::getRumRate() const
 inline void Port::setRumRate(double rum_rate)
 {
   this->rum_rate = rum_rate;
+}
+
+inline double Port::getRumPrice() const
+{
+  return max_rum - rum + 1.0;
 }
 
 inline const bool Port::isBuyPort() const

--- a/code/include/UIElement.hpp
+++ b/code/include/UIElement.hpp
@@ -18,7 +18,7 @@ class UIElement {
 		enum Orientation {TopLeft, TopRight, BottomLeft, BottomRight, Center};
 		
 		virtual void initialize(sf::Vector2f s, sf::Vector2u curRes, Orientation orient);
-                virtual void update(const HumanGameView* hgv);
+                virtual void update(HumanGameView* hgv);
 		virtual void resize(sf::Vector2u curRes);
 		virtual void draw(sf::RenderWindow* window);
 		

--- a/code/include/UIElement.hpp
+++ b/code/include/UIElement.hpp
@@ -3,6 +3,12 @@
 
 #include "SFML/Graphics.hpp"
 
+// Forward declaration of HumanGameView.  This is used instead of including
+// HumanGameView because including HumanGameView isn't necessary (only pointers
+// to HumanGameView are present here) and because including it can cause a
+// "circular include" type situation ...
+class HumanGameView;
+
 class UIElement {
 
 	public:
@@ -12,6 +18,7 @@ class UIElement {
 		enum Orientation {TopLeft, TopRight, BottomLeft, BottomRight, Center};
 		
 		virtual void initialize(sf::Vector2f s, sf::Vector2u curRes, Orientation orient);
+                virtual void update(const HumanGameView* hgv);
 		virtual void resize(sf::Vector2u curRes);
 		virtual void draw(sf::RenderWindow* window);
 		

--- a/code/include/UIElement.hpp
+++ b/code/include/UIElement.hpp
@@ -7,7 +7,7 @@ class UIElement {
 
 	public:
 		UIElement();
-		~UIElement();
+		virtual ~UIElement();
 		
 		enum Orientation {TopLeft, TopRight, BottomLeft, BottomRight, Center};
 		

--- a/code/include/UIPortData.hpp
+++ b/code/include/UIPortData.hpp
@@ -44,6 +44,8 @@ public:
 
   void loadFontFromFile(const std::string& font);
 
+  void setName(const std::string& name);
+
   void setRum(unsigned int rum);
 
   void setGold(unsigned int gold);
@@ -52,6 +54,9 @@ private:
 
   // The actor this is associated with
   ActorId actor_id;
+
+  // Text field for displaying the port's name
+  UITextField name_field;
 
   // Text field for displaying rum amount
   UITextField rum_field;
@@ -62,22 +67,28 @@ private:
 
 inline const sf::Vector2f& UIPortData::getPosition() const
 {
-  // The rum field draws at the top-left of this UI element so its position is
+  // The name field draws at the top-left of this UI element so its position is
   // the position of the whole thing
-  return rum_field.getPosition();
+  return name_field.getPosition();
 }
 
 inline unsigned int UIPortData::getCharacterSize() const
 {
   // Both fields are supposed to be set to the same character size, so just
   // return the size from one of them
-  return rum_field.getCharacterSize();
+  return name_field.getCharacterSize();
 }
 
 inline void UIPortData::setColor(const sf::Color& color)
 {
+  name_field.setColor(color);
   rum_field.setColor(color);
   gold_field.setColor(color);
+}
+
+inline void UIPortData::setName(const std::string& name)
+{
+  name_field.setText(name);
 }
 
 #endif

--- a/code/include/UIPortData.hpp
+++ b/code/include/UIPortData.hpp
@@ -29,6 +29,8 @@ public:
 
   void setCharacterSize(unsigned int size);
 
+  unsigned int getCharacterSize() const;
+
   void setColor(const sf::Color& color);
 
   void loadFontFromFile(const std::string& font);
@@ -51,6 +53,13 @@ inline const sf::Vector2f& UIPortData::getPosition() const
   // The rum field draws at the top-left of this UI element so its position is
   // the position of the whole thing
   return rum_field.getPosition();
+}
+
+inline unsigned int UIPortData::getCharacterSize() const
+{
+  // Both fields are supposed to be set to the same character size, so just
+  // return the size from one of them
+  return rum_field.getCharacterSize();
 }
 
 inline void UIPortData::setColor(const sf::Color& color)

--- a/code/include/UIPortData.hpp
+++ b/code/include/UIPortData.hpp
@@ -6,6 +6,12 @@
 #include "UIElement.hpp"
 #include "UITextField.hpp"
 
+// Forward declaration of HumanGameView.  This is used instead of including
+// HumanGameView because including HumanGameView isn't necessary (only pointers
+// to HumanGameView are present here) and because including it can cause a
+// "circular include" type situation ...
+class HumanGameView;
+
 class UIPortData : public UIElement
 {
 public:
@@ -19,6 +25,8 @@ public:
   virtual void initialize(sf::Vector2f s,
 			  sf::Vector2u curRes,
 			  Orientation  orient);
+
+  virtual void update(const HumanGameView* hgv);
 
   virtual void resize(sf::Vector2u curRes);
 

--- a/code/include/UIPortData.hpp
+++ b/code/include/UIPortData.hpp
@@ -1,0 +1,33 @@
+#if !defined UI_PORT_DATA_HPP
+#define UI_PORT_DATA_HPP
+
+#include "UIElement.hpp"
+#include "UITextField.hpp"
+
+class UIPortData : public UIElement
+{
+public:
+
+  UIPortData();
+
+  virtual ~UIPortData();
+
+  virtual void draw(sf::RenderWindow* window);
+
+  virtual void initialize(sf::Vector2f s,
+			  sf::Vector2u curRes,
+			  Orientation  orient);
+
+  virtual void resize(sf::Vector2u curRes);
+
+
+private:
+
+  // Text field for displaying rum amount
+  UITextField rum_field;
+
+  // Text field for displaying gold amount
+  UITextField gold_field;
+};
+
+#endif

--- a/code/include/UIPortData.hpp
+++ b/code/include/UIPortData.hpp
@@ -3,6 +3,7 @@
 
 #include <SFML/Graphics.hpp>
 
+#include "ActorId.hpp"
 #include "UIElement.hpp"
 #include "UITextField.hpp"
 
@@ -16,7 +17,7 @@ class UIPortData : public UIElement
 {
 public:
 
-  UIPortData();
+  UIPortData(ActorId actor_id);
 
   virtual ~UIPortData();
 
@@ -48,6 +49,9 @@ public:
   void setGold(unsigned int gold);
 
 private:
+
+  // The actor this is associated with
+  ActorId actor_id;
 
   // Text field for displaying rum amount
   UITextField rum_field;

--- a/code/include/UIPortData.hpp
+++ b/code/include/UIPortData.hpp
@@ -1,6 +1,8 @@
 #if !defined UI_PORT_DATA_HPP
 #define UI_PORT_DATA_HPP
 
+#include <SFML/Graphics.hpp>
+
 #include "UIElement.hpp"
 #include "UITextField.hpp"
 
@@ -21,6 +23,16 @@ public:
   virtual void resize(sf::Vector2u curRes);
 
 
+  void setPosition(const sf::Vector2f& position);
+
+  const sf::Vector2f& getPosition() const;
+
+  void setCharacterSize(unsigned int size);
+
+  void setColor(const sf::Color& color);
+
+  void loadFontFromFile(const std::string& font);
+
 private:
 
   // Text field for displaying rum amount
@@ -29,5 +41,18 @@ private:
   // Text field for displaying gold amount
   UITextField gold_field;
 };
+
+inline const sf::Vector2f& UIPortData::getPosition() const
+{
+  // The rum field draws at the top-left of this UI element so its position is
+  // the position of the whole thing
+  return rum_field.getPosition();
+}
+
+inline void UIPortData::setColor(const sf::Color& color)
+{
+  rum_field.setColor(color);
+  gold_field.setColor(color);
+}
 
 #endif

--- a/code/include/UIPortData.hpp
+++ b/code/include/UIPortData.hpp
@@ -26,7 +26,7 @@ public:
 			  sf::Vector2u curRes,
 			  Orientation  orient);
 
-  virtual void update(const HumanGameView* hgv);
+  virtual void update(HumanGameView* hgv);
 
   virtual void resize(sf::Vector2u curRes);
 

--- a/code/include/UIPortData.hpp
+++ b/code/include/UIPortData.hpp
@@ -33,6 +33,10 @@ public:
 
   void loadFontFromFile(const std::string& font);
 
+  void setRum(unsigned int rum);
+
+  void setGold(unsigned int gold);
+
 private:
 
   // Text field for displaying rum amount

--- a/code/include/UIShipData.hpp
+++ b/code/include/UIShipData.hpp
@@ -1,0 +1,62 @@
+#if !defined UI_SHIP_DATA_HPP
+#define UI_SHIP_DATA_HPP
+
+#include <SFML/Graphics.hpp>
+
+#include "UIElement.hpp"
+#include "UITextField.hpp"
+
+// Forward declaration of HumanGameView.  This is used instead of including
+// HumanGameView because including HumanGameView isn't necessary (only pointers
+// to HumanGameView are present here) and because including it can cause a
+// "circular include" type situation ...
+class HumanGameView;
+
+class UIShipData : public UIElement
+{
+public:
+
+  UIShipData();
+
+  virtual ~UIShipData();
+
+  virtual void initialize(sf::Vector2f s,
+			  sf::Vector2u curRes,
+			  Orientation orient);
+
+  virtual void update(HumanGameView* hgv);
+
+  virtual void resize(sf::Vector2u curRes);
+
+  virtual void draw(sf::RenderWindow* window);
+
+
+  void setGold(unsigned int gold);
+
+  void setRum(unsigned int rum);
+
+private:
+
+  void updateText();
+
+  // Displays ship data
+  UITextField text;
+
+  // Gold amount to be displayed
+  unsigned int gold;
+
+  // Rum amount to be displayed
+  unsigned int rum;
+};
+
+inline void UIShipData::setGold(unsigned int gold)
+{
+  this->gold = gold;
+}
+
+inline void UIShipData::setRum(unsigned int rum)
+{
+  this->rum = rum;
+}
+
+#endif

--- a/code/include/UIShipData.hpp
+++ b/code/include/UIShipData.hpp
@@ -31,9 +31,17 @@ public:
   virtual void draw(sf::RenderWindow* window);
 
 
+  void setPosition(const sf::Vector2f& position);
+
+  void setCharacterSize(unsigned int size);
+
   void setGold(unsigned int gold);
 
   void setRum(unsigned int rum);
+
+  void setColor(const sf::Color& color);
+
+  void setStyle(sf::Text::Style style);
 
 private:
 
@@ -49,6 +57,16 @@ private:
   unsigned int rum;
 };
 
+inline void UIShipData::setPosition(const sf::Vector2f& position)
+{
+  text.setPosition(position);
+}
+
+inline void UIShipData::setCharacterSize(unsigned int size)
+{
+  text.setCharacterSize(size);
+}
+
 inline void UIShipData::setGold(unsigned int gold)
 {
   this->gold = gold;
@@ -57,6 +75,16 @@ inline void UIShipData::setGold(unsigned int gold)
 inline void UIShipData::setRum(unsigned int rum)
 {
   this->rum = rum;
+}
+
+inline void UIShipData::setColor(const sf::Color& color)
+{
+  text.setColor(color);
+}
+
+inline void UIShipData::setStyle(sf::Text::Style style)
+{
+  text.setStyle(style);
 }
 
 #endif

--- a/code/include/UITextField.hpp
+++ b/code/include/UITextField.hpp
@@ -1,0 +1,23 @@
+#if !defined UI_TEXT_FIELD_HPP
+#define UI_TEXT_FIELD_HPP
+
+#include <SFML/Graphics.hpp>
+
+#include "UIElement.hpp"
+
+class UITextField : public UIElement
+{
+public:
+
+  UITextField();
+
+  virtual ~UITextField();
+
+private:
+
+  sf::Font font;
+
+  sf::Text text;
+};
+
+#endif

--- a/code/include/UITextField.hpp
+++ b/code/include/UITextField.hpp
@@ -5,6 +5,7 @@
 
 #include "UIElement.hpp"
 
+// This class represents a simple text field.
 class UITextField : public UIElement
 {
 public:

--- a/code/include/UITextField.hpp
+++ b/code/include/UITextField.hpp
@@ -13,11 +13,45 @@ public:
 
   virtual ~UITextField();
 
+  virtual void draw(sf::RenderWindow* window);
+
+  virtual void initialize(sf::Vector2f s,
+			  sf::Vector2u curRes,
+			  Orientation  orient);
+
+  virtual void resize(sf::Vector2u curRes);
+
+
+  void setPosition(const sf::Vector2f& position);
+
+  void setCharacterSize(unsigned int size);
+
+  void setText(const std::string& text);
+
+  void loadFontFromFile(const std::string& font);
+
 private:
 
+  // The font the text in this text field will be drawn in
   sf::Font font;
 
+  // The actual text of concern for this text field
   sf::Text text;
 };
+
+inline void UITextField::setPosition(const sf::Vector2f& position)
+{
+  text.setPosition(position);
+}
+
+inline void UITextField::setCharacterSize(unsigned int size)
+{
+  text.setCharacterSize(size);
+}
+
+inline void UITextField::setText(const std::string& text)
+{
+  this->text.setString(text);
+}
 
 #endif

--- a/code/include/UITextField.hpp
+++ b/code/include/UITextField.hpp
@@ -5,6 +5,12 @@
 
 #include "UIElement.hpp"
 
+// Forward declaration of HumanGameView.  This is used instead of including
+// HumanGameView because including HumanGameView isn't necessary (only pointers
+// to HumanGameView are present here) and because including it can cause a
+// "circular include" type situation ...
+class HumanGameView;
+
 // This class represents a simple text field.
 class UITextField : public UIElement
 {
@@ -19,6 +25,8 @@ public:
   virtual void initialize(sf::Vector2f s,
 			  sf::Vector2u curRes,
 			  Orientation  orient);
+
+  virtual void update(const HumanGameView* hgv);
 
   virtual void resize(sf::Vector2u curRes);
 

--- a/code/include/UITextField.hpp
+++ b/code/include/UITextField.hpp
@@ -25,11 +25,17 @@ public:
 
   void setPosition(const sf::Vector2f& position);
 
+  const sf::Vector2f& getPosition() const;
+
   void setCharacterSize(unsigned int size);
+
+  unsigned int getCharacterSize() const;
 
   void setText(const std::string& text);
 
-  void loadFontFromFile(const std::string& font);
+  void setColor(const sf::Color& color);
+
+  bool loadFontFromFile(const std::string& font);
 
 private:
 
@@ -45,14 +51,29 @@ inline void UITextField::setPosition(const sf::Vector2f& position)
   text.setPosition(position);
 }
 
+inline const sf::Vector2f& UITextField::getPosition() const
+{
+  return text.getPosition();
+}
+
 inline void UITextField::setCharacterSize(unsigned int size)
 {
   text.setCharacterSize(size);
 }
 
+inline unsigned int UITextField::getCharacterSize() const
+{
+  return text.getCharacterSize();
+}
+
 inline void UITextField::setText(const std::string& text)
 {
   this->text.setString(text);
+}
+
+inline void UITextField::setColor(const sf::Color& color)
+{
+  text.setColor(color);
 }
 
 #endif

--- a/code/include/UITextField.hpp
+++ b/code/include/UITextField.hpp
@@ -43,6 +43,8 @@ public:
 
   void setColor(const sf::Color& color);
 
+  void setStyle(sf::Text::Style style);
+
   bool loadFontFromFile(const std::string& font);
 
 private:
@@ -82,6 +84,11 @@ inline void UITextField::setText(const std::string& text)
 inline void UITextField::setColor(const sf::Color& color)
 {
   text.setColor(color);
+}
+
+inline void UITextField::setStyle(sf::Text::Style style)
+{
+  text.setStyle(style);
 }
 
 #endif

--- a/code/include/UITextField.hpp
+++ b/code/include/UITextField.hpp
@@ -26,7 +26,7 @@ public:
 			  sf::Vector2u curRes,
 			  Orientation  orient);
 
-  virtual void update(const HumanGameView* hgv);
+  virtual void update(HumanGameView* hgv);
 
   virtual void resize(sf::Vector2u curRes);
 

--- a/code/include/UITextInput.hpp
+++ b/code/include/UITextInput.hpp
@@ -13,7 +13,7 @@ class UITextInput : public UIElement {
 	
 public:
 	virtual void initialize(sf::Vector2f s, sf::Vector2u curRes, Orientation orient);
-        virtual void update(const HumanGameView* hgv);
+        virtual void update(HumanGameView* hgv);
 	virtual void resize(sf::Vector2u curRes);
 	virtual void draw(sf::RenderWindow* window);
 	virtual void setDialogue(std::string str);

--- a/code/include/UITextInput.hpp
+++ b/code/include/UITextInput.hpp
@@ -3,10 +3,17 @@
 
 #include "UIElement.hpp"
 
+// Forward declaration of HumanGameView.  This is used instead of including
+// HumanGameView because including HumanGameView isn't necessary (only pointers
+// to HumanGameView are present here) and because including it can cause a
+// "circular include" type situation ...
+class HumanGameView;
+
 class UITextInput : public UIElement {
 	
 public:
 	virtual void initialize(sf::Vector2f s, sf::Vector2u curRes, Orientation orient);
+        virtual void update(const HumanGameView* hgv);
 	virtual void resize(sf::Vector2u curRes);
 	virtual void draw(sf::RenderWindow* window);
 	virtual void setDialogue(std::string str);
@@ -27,4 +34,5 @@ private:
 	std::string dialogue;
 	sf::Text dialogueText;
 };
+
 #endif

--- a/code/src/GameLogic.cpp
+++ b/code/src/GameLogic.cpp
@@ -32,8 +32,8 @@ GameLogic::GameLogic() :
   ship->setPositionX(10);
   ship->setPositionY(11);
   ship->setMinMoveTime(1.0);
-  ship->setGold(0);
-  ship->setRum(1);
+  ship->setGold(10);
+  ship->setRum(5);
   ship->setMaxRum(10);
   ship->setRumRate(0);
 

--- a/code/src/GameLogic.cpp
+++ b/code/src/GameLogic.cpp
@@ -272,7 +272,7 @@ void GameLogic::TransactionCheckEventHandler(const EventInterface& event)
   portrum = tcheck_event->getPortRum();
   rumrequest = tcheck_event->getRumRequest();
   
-  price = 11 - portrum;
+  price = ports[portid]->getRumPrice();
   
   if (ports[portid]->isBuyPort() && rumrequest <= portrum && rumrequest * price <= shipgold)
   {

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -92,6 +92,8 @@ void HumanGameView::update(const sf::Time& delta_t)
 
   drawMap();
   drawActors();
+
+  updateUI();
   drawUI();
 
   // Can use App to draw in the game window
@@ -176,6 +178,16 @@ void HumanGameView::readInputs(const sf::Time& delta_t) {
 		getGameLogic()->getEventManager()->queueEvent(sm_event);
 	}
   }
+}
+
+void HumanGameView::updateUI()
+{
+  // Update all the UI elements
+  for (UIElement* elem : uiList)
+  {
+    elem->update(this);
+  }
+
 }
 
 // draws the map

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -20,6 +20,7 @@ HumanGameView::HumanGameView(GameLogic* game_logic, sf::RenderWindow* App) :
 
 HumanGameView::~HumanGameView()
 {
+  delete test;
 }
 
 bool HumanGameView::initialize()

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -23,6 +23,14 @@ HumanGameView::HumanGameView(GameLogic* game_logic, sf::RenderWindow* App) :
 HumanGameView::~HumanGameView()
 {
   delete test;
+
+  // Delete all the UI elements associated with the ports
+  for (std::map<ActorId, UIPortData*>::iterator i = port_ui_data.begin();
+       i != port_ui_data.end();
+       i++)
+  {
+    delete i->second;
+  }
 }
 
 bool HumanGameView::initialize()
@@ -59,7 +67,28 @@ bool HumanGameView::initialize()
        i != ports_list->end();
        i++)
   {
+    // Make a new UIPortData for this port
+    UIPortData* new_ui_port_data = new UIPortData();
 
+    // Hold on to the new UI port data element by creating a mapping for it in
+    // the structure for this purpose
+    port_ui_data[i->first] = new_ui_port_data;
+
+    // Go ahead and initialize some of the data
+
+    // Set the correct position in the window for it
+    sf::Vector2f map_position(i->second->getPositionX(),
+			      i->second->getPositionY());
+
+    sf::Vector2f window_position;
+    mapToWindow(map_position, window_position);
+
+    new_ui_port_data->setPosition(window_position);
+    new_ui_port_data->setGold(i->second->getRumPrice());
+    new_ui_port_data->setRum(i->second->getRum());
+
+    // Add the port data to the UI list
+    uiList.push_back(new_ui_port_data);
   }
 
   return true;
@@ -354,8 +383,8 @@ void HumanGameView::calculateMapWindowData()
   }
 }
 
-bool HumanGameView::mapToWindow(const sf::Vector2u& map_coords,
-				sf::Vector2u&       window_coords)
+bool HumanGameView::mapToWindow(const sf::Vector2f& map_coords,
+				sf::Vector2f&       window_coords)
 {
   // No conversion possible if input isn't on the map
   if (map_coords.x > tempMap.get_map_size_x() - 1 ||
@@ -370,8 +399,8 @@ bool HumanGameView::mapToWindow(const sf::Vector2u& map_coords,
   return true;
 }
 
-bool HumanGameView::windowToMap(const sf::Vector2u& window_coords,
-				sf::Vector2u&       map_coords)
+bool HumanGameView::windowToMap(const sf::Vector2f& window_coords,
+				sf::Vector2f&       map_coords)
 {
   sf::Vector2u window_size = App->getSize();
 

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -59,6 +59,7 @@ bool HumanGameView::initialize()
 			    std::placeholders::_1)),
     TransactionStartEvent::event_type);
 
+
   // Grab a shortcut to the ports list
   const GameLogic::PortsList* ports_list = &getGameLogic()->getPortsList();
 
@@ -73,19 +74,6 @@ bool HumanGameView::initialize()
     // Hold on to the new UI port data element by creating a mapping for it in
     // the structure for this purpose
     port_ui_data[i->first] = new_ui_port_data;
-
-    // Go ahead and initialize some of the data
-
-    // Set the correct position in the window for it
-    sf::Vector2f map_position(i->second->getPositionX(),
-			      i->second->getPositionY());
-
-    sf::Vector2f window_position;
-    mapToWindow(map_position, window_position);
-
-    new_ui_port_data->setPosition(window_position);
-    new_ui_port_data->setGold(i->second->getRumPrice());
-    new_ui_port_data->setRum(i->second->getRum());
 
     // Add the port data to the UI list
     uiList.push_back(new_ui_port_data);

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
+
 #include "HumanGameView.hpp"
+#include "UITextField.hpp"
 
 HumanGameView::HumanGameView(GameLogic* game_logic, sf::RenderWindow* App) :
   GameView(game_logic),
@@ -30,21 +32,36 @@ bool HumanGameView::initialize()
   if (!tempMap.createMap("./data/second_map.txt")) {
 	std::cout << "ERROR MAP" << std::endl;
   }
+
   getGameLogic()->getEventManager()->addDelegate(
     EventDelegate(std::bind(&HumanGameView::transactionFailEventHandler,
 			    this,
 			    std::placeholders::_1)),
     TransactionFailEvent::event_type);
-	getGameLogic()->getEventManager()->addDelegate(
+
+  getGameLogic()->getEventManager()->addDelegate(
     EventDelegate(std::bind(&HumanGameView::transactionSuccessEventHandler,
 			    this,
 			    std::placeholders::_1)),
     TransactionSuccessEvent::event_type);
-	getGameLogic()->getEventManager()->addDelegate(
+
+  getGameLogic()->getEventManager()->addDelegate(
     EventDelegate(std::bind(&HumanGameView::transactionStartEventHandler,
 			    this,
 			    std::placeholders::_1)),
     TransactionStartEvent::event_type);
+
+  // Grab a shortcut to the ports list
+  const GameLogic::PortsList* ports_list = &getGameLogic()->getPortsList();
+
+  // Set up text fields for all the ports, their data will be displayed in these
+  for (GameLogic::PortsList::const_iterator i = ports_list->begin();
+       i != ports_list->end();
+       i++)
+  {
+
+  }
+
   return true;
 }
 

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -24,12 +24,12 @@ HumanGameView::~HumanGameView()
 {
   delete test;
 
-  // Delete all the UI elements associated with the ports
-  for (std::map<ActorId, UIPortData*>::iterator i = port_ui_data.begin();
-       i != port_ui_data.end();
+  // Delete all the UI elements
+  for (std::vector<UIElement*>::iterator i = uiList.begin();
+       i != uiList.end();
        i++)
   {
-    delete i->second;
+    delete *i;
   }
 }
 
@@ -69,11 +69,7 @@ bool HumanGameView::initialize()
        i++)
   {
     // Make a new UIPortData for this port
-    UIPortData* new_ui_port_data = new UIPortData();
-
-    // Hold on to the new UI port data element by creating a mapping for it in
-    // the structure for this purpose
-    port_ui_data[i->first] = new_ui_port_data;
+    UIPortData* new_ui_port_data = new UIPortData(i->first);
 
     // Add the port data to the UI list
     uiList.push_back(new_ui_port_data);

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -71,6 +71,9 @@ bool HumanGameView::initialize()
     // Make a new UIPortData for this port
     UIPortData* new_ui_port_data = new UIPortData(i->first);
 
+    // Set all the port names here, they're not going to change during runtime
+    new_ui_port_data->setName(i->second->getName());
+
     // Add the port data to the UI list
     uiList.push_back(new_ui_port_data);
   }

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -2,6 +2,7 @@
 
 #include "HumanGameView.hpp"
 #include "UITextField.hpp"
+#include "UIShipData.hpp"
 
 HumanGameView::HumanGameView(GameLogic* game_logic, sf::RenderWindow* App) :
   GameView(game_logic),
@@ -58,6 +59,10 @@ bool HumanGameView::initialize()
 			    this,
 			    std::placeholders::_1)),
     TransactionStartEvent::event_type);
+
+
+  // Push the UI ship data element onto the element list
+  uiList.push_back(new UIShipData());
 
 
   // Grab a shortcut to the ports list

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -187,7 +187,6 @@ void HumanGameView::updateUI()
   {
     elem->update(this);
   }
-
 }
 
 // draws the map

--- a/code/src/UIElement.cpp
+++ b/code/src/UIElement.cpp
@@ -1,3 +1,4 @@
+#include "HumanGameView.hpp"
 #include "UIElement.hpp"
 #include <iostream>
 
@@ -14,6 +15,10 @@ void UIElement::initialize(sf::Vector2f s, sf::Vector2u curRes, Orientation orie
 	size = s;
 	orientation = orient;
 	resize(curRes);
+}
+
+void UIElement::update(const HumanGameView* hgv)
+{
 }
 
 // reorients in screen space on a resize

--- a/code/src/UIElement.cpp
+++ b/code/src/UIElement.cpp
@@ -17,7 +17,7 @@ void UIElement::initialize(sf::Vector2f s, sf::Vector2u curRes, Orientation orie
 	resize(curRes);
 }
 
-void UIElement::update(const HumanGameView* hgv)
+void UIElement::update(HumanGameView* hgv)
 {
 }
 

--- a/code/src/UIPortData.cpp
+++ b/code/src/UIPortData.cpp
@@ -49,6 +49,10 @@ void UIPortData::update(HumanGameView* hgv)
   // Grab a convenience pointer back to the port we're interested in
   const Port* port = hgv->getGameLogic()->getPortsList().at(actor_id);
 
+  setGold(port->getRumPrice());
+  setRum(port->getRum());
+  setCharacterSize(hgv->getMapTileSize() / 2);  // adjust for prettiness
+
   // Convert port position into vector
   sf::Vector2f map_position(port->getPositionX(), port->getPositionY());
 
@@ -56,9 +60,6 @@ void UIPortData::update(HumanGameView* hgv)
   hgv->mapToWindow(map_position, window_position);
 
   setPosition(window_position);
-
-  setGold(port->getRumPrice());
-  setRum(port->getRum());
 }
 
 void UIPortData::resize(sf::Vector2u curRes)

--- a/code/src/UIPortData.cpp
+++ b/code/src/UIPortData.cpp
@@ -1,10 +1,16 @@
 #include <SFML/Graphics.hpp>
+#include <iostream>
 
 #include "UIPortData.hpp"
 
 UIPortData::UIPortData() :
   UIElement()
 {
+  // Port data displayed in white
+  setColor(sf::Color::White);
+
+  // Port data initially displayed in 10 pixel size
+  setCharacterSize(10);
 }
 
 UIPortData::~UIPortData()
@@ -13,6 +19,8 @@ UIPortData::~UIPortData()
 
 void UIPortData::draw(sf::RenderWindow* window)
 {
+  rum_field.draw(window);
+  gold_field.draw(window);
 }
 
 void UIPortData::initialize(sf::Vector2f s,
@@ -23,4 +31,43 @@ void UIPortData::initialize(sf::Vector2f s,
 
 void UIPortData::resize(sf::Vector2u curRes)
 {
+}
+
+
+void UIPortData::setPosition(const sf::Vector2f& position)
+{
+  // The rum field is displayed on top so it should be set to this position
+  rum_field.setPosition(position);
+
+  // The gold field is displayed below the rum field.  Where this is depends on
+  // the current character size.
+
+  // Grab current rum field position and set the gold field to be below it
+  sf::Vector2f new_gold_field_position = rum_field.getPosition();
+  new_gold_field_position.y += rum_field.getCharacterSize();
+  gold_field.setPosition(new_gold_field_position);
+}
+
+void UIPortData::setCharacterSize(unsigned int size)
+{
+  // First off just set the field character sizes
+  rum_field.setCharacterSize(size);
+  gold_field.setCharacterSize(size);
+
+  // Changing character means the gold field will need to be repositioned, so
+  // just call setPosition to the currently location and that will happen
+  setPosition(getPosition());
+}
+
+void UIPortData::loadFontFromFile(const std::string& font)
+{
+  if (!rum_field.loadFontFromFile(font))
+  {
+    std::cerr << "Couldn't load UIPortData rum font\n";
+  }
+
+  if (!gold_field.loadFontFromFile(font))
+  {
+    std::cerr << "Couldn't load UIPortData gold font\n";
+  }
 }

--- a/code/src/UIPortData.cpp
+++ b/code/src/UIPortData.cpp
@@ -1,0 +1,26 @@
+#include <SFML/Graphics.hpp>
+
+#include "UIPortData.hpp"
+
+UIPortData::UIPortData() :
+  UIElement()
+{
+}
+
+UIPortData::~UIPortData()
+{
+}
+
+void UIPortData::draw(sf::RenderWindow* window)
+{
+}
+
+void UIPortData::initialize(sf::Vector2f s,
+			    sf::Vector2u curRes,
+			    Orientation  orient)
+{
+}
+
+void UIPortData::resize(sf::Vector2u curRes)
+{
+}

--- a/code/src/UIPortData.cpp
+++ b/code/src/UIPortData.cpp
@@ -3,12 +3,14 @@
 #include <sstream>
 #include <string>
 
+#include "ActorId.hpp"
 #include "GameLogic.hpp"
 #include "HumanGameView.hpp"
 #include "UIPortData.hpp"
 
-UIPortData::UIPortData() :
-  UIElement()
+UIPortData::UIPortData(ActorId actor_id) :
+  UIElement(),
+  actor_id(actor_id)
 {
   // Port data displayed in white
   setColor(sf::Color::White);
@@ -39,9 +41,19 @@ void UIPortData::initialize(sf::Vector2f s,
 
 void UIPortData::update(HumanGameView* hgv)
 {
-  // Grab a convenience pointer back to the port list in the game logic
-  const GameLogic::PortsList* ports_list = &hgv->getGameLogic()->getPortsList();
-  //const PortList* port
+  // Grab a convenience pointer back to the port we're interested in
+  const Port* port = hgv->getGameLogic()->getPortsList().at(actor_id);
+
+  // Convert port position into vector
+  sf::Vector2f map_position(port->getPositionX(), port->getPositionY());
+
+  sf::Vector2f window_position;
+  hgv->mapToWindow(map_position, window_position);
+
+  setPosition(window_position);
+
+  setGold(port->getRumPrice());
+  setRum(port->getRum());
 }
 
 void UIPortData::resize(sf::Vector2u curRes)

--- a/code/src/UIPortData.cpp
+++ b/code/src/UIPortData.cpp
@@ -1,5 +1,7 @@
 #include <SFML/Graphics.hpp>
 #include <iostream>
+#include <sstream>
+#include <string>
 
 #include "UIPortData.hpp"
 
@@ -11,6 +13,10 @@ UIPortData::UIPortData() :
 
   // Port data initially displayed in 10 pixel size
   setCharacterSize(10);
+
+  // Defaults
+  setRum(0);
+  setGold(0);
 }
 
 UIPortData::~UIPortData()
@@ -55,7 +61,7 @@ void UIPortData::setCharacterSize(unsigned int size)
   gold_field.setCharacterSize(size);
 
   // Changing character means the gold field will need to be repositioned, so
-  // just call setPosition to the currently location and that will happen
+  // just call setPosition to the currentl location and that will happen
   setPosition(getPosition());
 }
 
@@ -70,4 +76,24 @@ void UIPortData::loadFontFromFile(const std::string& font)
   {
     std::cerr << "Couldn't load UIPortData gold font\n";
   }
+}
+
+void UIPortData::setRum(unsigned int rum)
+{
+  // Convert the given number into a string
+  std::ostringstream num_to_str;
+  num_to_str << rum;
+
+  // Plow everything into the rum field
+  rum_field.setText(num_to_str.str() + " R");
+}
+
+void UIPortData::setGold(unsigned int gold)
+{
+  // Convert the given number into a string
+  std::ostringstream num_to_str;
+  num_to_str << gold;
+
+  // Plow everything into the rum field
+  gold_field.setText(num_to_str.str() + " G");
 }

--- a/code/src/UIPortData.cpp
+++ b/code/src/UIPortData.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <string>
 
+#include "HumanGameView.hpp"
 #include "UIPortData.hpp"
 
 UIPortData::UIPortData() :
@@ -32,6 +33,10 @@ void UIPortData::draw(sf::RenderWindow* window)
 void UIPortData::initialize(sf::Vector2f s,
 			    sf::Vector2u curRes,
 			    Orientation  orient)
+{
+}
+
+void UIPortData::update(const HumanGameView* hgv)
 {
 }
 

--- a/code/src/UIPortData.cpp
+++ b/code/src/UIPortData.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <string>
 
+#include "GameLogic.hpp"
 #include "HumanGameView.hpp"
 #include "UIPortData.hpp"
 
@@ -36,8 +37,11 @@ void UIPortData::initialize(sf::Vector2f s,
 {
 }
 
-void UIPortData::update(const HumanGameView* hgv)
+void UIPortData::update(HumanGameView* hgv)
 {
+  // Grab a convenience pointer back to the port list in the game logic
+  const GameLogic::PortsList* ports_list = &hgv->getGameLogic()->getPortsList();
+  //const PortList* port
 }
 
 void UIPortData::resize(sf::Vector2u curRes)

--- a/code/src/UIPortData.cpp
+++ b/code/src/UIPortData.cpp
@@ -19,8 +19,12 @@ UIPortData::UIPortData(ActorId actor_id) :
   setCharacterSize(10);
 
   // Defaults
+  setName("UIPortData");
   setRum(0);
   setGold(0);
+
+  // The name field is always bold
+  name_field.setStyle(sf::Text::Bold);
 }
 
 UIPortData::~UIPortData()
@@ -29,6 +33,7 @@ UIPortData::~UIPortData()
 
 void UIPortData::draw(sf::RenderWindow* window)
 {
+  name_field.draw(window);
   rum_field.draw(window);
   gold_field.draw(window);
 }
@@ -60,24 +65,26 @@ void UIPortData::resize(sf::Vector2u curRes)
 {
 }
 
-
 void UIPortData::setPosition(const sf::Vector2f& position)
 {
-  // The rum field is displayed on top so it should be set to this position
-  rum_field.setPosition(position);
+  // The name field is displayed on top so it should be set to this position
+  name_field.setPosition(position);
 
-  // The gold field is displayed below the rum field.  Where this is depends on
-  // the current character size.
+  // The other fields are displayed below the name field.  Where they are
+  // depends on the current character size
 
-  // Grab current rum field position and set the gold field to be below it
-  sf::Vector2f new_gold_field_position = rum_field.getPosition();
-  new_gold_field_position.y += rum_field.getCharacterSize();
-  gold_field.setPosition(new_gold_field_position);
+  // Grab current name field position and set the other fields to be below it
+  sf::Vector2f new_field_position = name_field.getPosition();
+  new_field_position.y += name_field.getCharacterSize();
+  rum_field.setPosition(new_field_position);
+  new_field_position.y += name_field.getCharacterSize();
+  gold_field.setPosition(new_field_position);
 }
 
 void UIPortData::setCharacterSize(unsigned int size)
 {
   // First off just set the field character sizes
+  name_field.setCharacterSize(size);
   rum_field.setCharacterSize(size);
   gold_field.setCharacterSize(size);
 
@@ -88,6 +95,11 @@ void UIPortData::setCharacterSize(unsigned int size)
 
 void UIPortData::loadFontFromFile(const std::string& font)
 {
+  if (!name_field.loadFontFromFile(font))
+  {
+    std::cerr << "Couldn't load UIPortData name font\n";
+  }
+
   if (!rum_field.loadFontFromFile(font))
   {
     std::cerr << "Couldn't load UIPortData rum font\n";

--- a/code/src/UIShipData.cpp
+++ b/code/src/UIShipData.cpp
@@ -10,6 +10,7 @@ UIShipData::UIShipData() :
   gold(0)
 {
   // Defaults
+  setPosition(sf::Vector2f(0, 0));
   setColor(sf::Color::White);
   setStyle(sf::Text::Bold);
 }
@@ -28,6 +29,12 @@ void UIShipData::update(HumanGameView* hgv)
 {
   // Adjust for prettiness
   setCharacterSize(static_cast<double>(hgv->getMapTileSize()) * 0.75);
+
+  // Grab convenience pointer to ship
+  const Ship* ship = hgv->getGameLogic()->getShip();
+
+  setRum(ship->getRum());
+  setGold(ship->getGold());
 
   updateText();
 }

--- a/code/src/UIShipData.cpp
+++ b/code/src/UIShipData.cpp
@@ -1,0 +1,34 @@
+#include <SFML/Graphics.hpp>
+
+#include "UIShipData.hpp"
+
+UIShipData::UIShipData() :
+  UIElement()
+{
+}
+
+UIShipData::~UIShipData()
+{
+}
+
+void UIShipData::initialize(sf::Vector2f s,
+			    sf::Vector2u curRes,
+			    Orientation  orient)
+{
+}
+
+void UIShipData::update(HumanGameView* hgv)
+{
+}
+
+void UIShipData::resize(sf::Vector2u curRes)
+{
+}
+
+void UIShipData::draw(sf::RenderWindow* window)
+{
+}
+
+void UIShipData::updateText()
+{
+}

--- a/code/src/UIShipData.cpp
+++ b/code/src/UIShipData.cpp
@@ -1,10 +1,17 @@
 #include <SFML/Graphics.hpp>
+#include <sstream>
 
+#include "HumanGameView.hpp"
 #include "UIShipData.hpp"
 
 UIShipData::UIShipData() :
-  UIElement()
+  UIElement(),
+  rum(0),
+  gold(0)
 {
+  // Defaults
+  setColor(sf::Color::White);
+  setStyle(sf::Text::Bold);
 }
 
 UIShipData::~UIShipData()
@@ -19,6 +26,10 @@ void UIShipData::initialize(sf::Vector2f s,
 
 void UIShipData::update(HumanGameView* hgv)
 {
+  // Adjust for prettiness
+  setCharacterSize(static_cast<double>(hgv->getMapTileSize()) * 0.75);
+
+  updateText();
 }
 
 void UIShipData::resize(sf::Vector2u curRes)
@@ -27,8 +38,22 @@ void UIShipData::resize(sf::Vector2u curRes)
 
 void UIShipData::draw(sf::RenderWindow* window)
 {
+  text.draw(window);
 }
 
 void UIShipData::updateText()
 {
+  // Will hold the text as it is formed
+  std::string updated_text;
+
+  // Convert rum and gold into text
+  std::ostringstream num_to_str;
+  num_to_str << rum;
+  updated_text = num_to_str.str() + " R ";
+
+  num_to_str.str("");
+  num_to_str << gold;
+  updated_text += num_to_str.str() + " G";
+
+  text.setText(updated_text);
 }

--- a/code/src/UITextField.cpp
+++ b/code/src/UITextField.cpp
@@ -1,6 +1,7 @@
 #include <SFML/Graphics.hpp>
 #include <iostream>
 
+#include "HumanGameView.hpp"
 #include "UITextField.hpp"
 
 UITextField::UITextField() :
@@ -31,6 +32,10 @@ void UITextField::draw(sf::RenderWindow* window)
 void UITextField::initialize(sf::Vector2f s,
 			     sf::Vector2u curRes,
 			     Orientation orient)
+{
+}
+
+void UITextField::update(const HumanGameView* hgv)
 {
 }
 

--- a/code/src/UITextField.cpp
+++ b/code/src/UITextField.cpp
@@ -1,12 +1,49 @@
 #include <SFML/Graphics.hpp>
+#include <iostream>
 
 #include "UITextField.hpp"
 
 UITextField::UITextField() :
   UIElement()
 {
+  // Load Arial by default
+  loadFontFromFile("Arial.ttf");
+
+  // Set the default font
+  text.setFont(font);
+
+  // Sets defaults for the rest of the text properties
+  text.setPosition(0, 0);
+  text.setCharacterSize(10);
+  text.setColor(sf::Color::Black);
+  text.setString("UITextField");
 }
 
 UITextField::~UITextField()
 {
+}
+
+void UITextField::draw(sf::RenderWindow* window)
+{
+  window->draw(text);
+}
+
+void UITextField::initialize(sf::Vector2f s,
+			     sf::Vector2u curRes,
+			     Orientation orient)
+{
+}
+
+void UITextField::resize(sf::Vector2u curRes)
+{
+}
+
+void UITextField::loadFontFromFile(const std::string& font)
+{
+  if (!this->font.loadFromFile(font))
+  {
+    std::cerr << "Couldn't load UITextField font\n";
+  }
+
+  text.setFont(this->font);
 }

--- a/code/src/UITextField.cpp
+++ b/code/src/UITextField.cpp
@@ -35,7 +35,7 @@ void UITextField::initialize(sf::Vector2f s,
 {
 }
 
-void UITextField::update(const HumanGameView* hgv)
+void UITextField::update(HumanGameView* hgv)
 {
 }
 

--- a/code/src/UITextField.cpp
+++ b/code/src/UITextField.cpp
@@ -1,0 +1,12 @@
+#include <SFML/Graphics.hpp>
+
+#include "UITextField.hpp"
+
+UITextField::UITextField() :
+  UIElement()
+{
+}
+
+UITextField::~UITextField()
+{
+}

--- a/code/src/UITextField.cpp
+++ b/code/src/UITextField.cpp
@@ -38,12 +38,15 @@ void UITextField::resize(sf::Vector2u curRes)
 {
 }
 
-void UITextField::loadFontFromFile(const std::string& font)
+bool UITextField::loadFontFromFile(const std::string& font)
 {
   if (!this->font.loadFromFile(font))
   {
     std::cerr << "Couldn't load UITextField font\n";
+    return false;
   }
 
   text.setFont(this->font);
+
+  return true;
 }

--- a/code/src/UITextInput.cpp
+++ b/code/src/UITextInput.cpp
@@ -19,7 +19,7 @@ void UITextInput::initialize(sf::Vector2f s, sf::Vector2u curRes, Orientation or
 	dialogueText.setString(dialogue);
 }
 
-void UITextInput::update(const HumanGameView* hgv)
+void UITextInput::update(HumanGameView* hgv)
 {
 }
 

--- a/code/src/UITextInput.cpp
+++ b/code/src/UITextInput.cpp
@@ -1,3 +1,4 @@
+#include "HumanGameView.hpp"
 #include "UITextInput.hpp"
 
 void UITextInput::initialize(sf::Vector2f s, sf::Vector2u curRes, Orientation orient) {
@@ -16,6 +17,10 @@ void UITextInput::initialize(sf::Vector2f s, sf::Vector2u curRes, Orientation or
 	dialogueText.setFont(font);
 	dialogueText.setCharacterSize(20);
 	dialogueText.setString(dialogue);
+}
+
+void UITextInput::update(const HumanGameView* hgv)
+{
 }
 
 void UITextInput::resize(sf::Vector2u curRes) {


### PR DESCRIPTION
Okay, here's a working UI that shows ship data as well as data for all the ports.  It all changes position and size as the window changes size, and it all updates in real-time.  Try it out and see what you think.

I added 3 new UIElements: UITextField (shows a simple text string), UIPortData (shows the data associated with a port), and UIShipData (shows the data associated with the ship).  To get these to update I added a new "update" function to UIElement.  HumanGameView now updates all UIElements each frame.

mapToWindow() and windowToMap() changed to take sf::Vector2f rather than sf::Vector2u arguments, because SFML positions everything with sf::Vector2f vectors for some reason.

Port now has a member function that returns the price of rum that that port.  There are a couple places where we've hardcoded the rum price at a port.  Now that this exists we don't have to do that anymore.

The 'test' UITextInput field in HumanGameView is now deleted when the HumanGameView is, and the same now goes for all UIElements.
