### PR TITLE
I am not sure if this bothered anyone else, but this change moves the in...

### DIFF
--- a/code/src/UITextInput.cpp
+++ b/code/src/UITextInput.cpp
@@ -11,7 +11,7 @@ void UITextInput::initialize(sf::Vector2f s, sf::Vector2u curRes, Orientation or
 	font.loadFromFile("Arial.ttf");
 	input = ":";
 	inputText.setFont(font);
-	inputText.setString(input);
+	inputText.setString('\n'+input);
 	inputText.setCharacterSize(20);
 	dialogue = "Rum Supply X\nPrice Y";
 	dialogueText.setFont(font);
@@ -38,14 +38,14 @@ void UITextInput::setDialogue(std::string str) {
 void UITextInput::inputPush(char c) {
 	if (input.length() < 7) {
 		input += c;
-		inputText.setString(input);
+		inputText.setString('\n'+input);
 	}
 }
 
 void UITextInput::inputPop() {
 	if (input.length() > 1) {
 		input.pop_back();
-		inputText.setString(input);
+		inputText.setString('\n'+input);
 	}
 }
 
@@ -55,7 +55,7 @@ int UITextInput::clearInput() {
 		input = input.substr(1, input.length());
 		sscanf(input.c_str(), "%d", &i);
 		input = ":";
-		inputText.setString(input);
+		inputText.setString('\n'+input);
 		return i;
 	}
 	return -1;


### PR DESCRIPTION
...put section of the UI window to the bottom of the window. So when a transaction fails to occur, the input is not covered up by the dialog text. Currently, the new line that says Transaction Failed pushes the Supply and Price lines down, which covers up the input. This looks a little weird when the transaction has not failed yet but overall it is better, I think.
