### PR TITLE
Integer rum gold

### DIFF
--- a/code/include/HumanGameView.hpp
+++ b/code/include/HumanGameView.hpp
@@ -119,9 +119,9 @@ private:
   // temp ints for storing transaction event data
   ActorId tc_shipid;
   ActorId tc_portid;
-  int tc_shipgold;
-  int tc_shiprum;
-  int tc_portrum;
+  unsigned int tc_shipgold;
+  unsigned int tc_shiprum;
+  unsigned int tc_portrum;
 };
 
 inline unsigned int HumanGameView::getMapTileSize() const

--- a/code/include/Port.hpp
+++ b/code/include/Port.hpp
@@ -86,6 +86,10 @@ inline double Port::getRumRate() const
 inline void Port::setRumRate(double rum_rate)
 {
   this->rum_rate = rum_rate;
+
+  // We want to do this to avoid massive rum changes when changing from a low
+  // rum rate to a high rum rate
+  rum_time = 0.0;
 }
 
 inline unsigned int Port::getRumPrice() const

--- a/code/include/Port.hpp
+++ b/code/include/Port.hpp
@@ -20,19 +20,19 @@ public:
 
   virtual void update(const sf::Time& delta_t);
   
-  double getRum() const;
+  unsigned int getRum() const;
 
-  void setRum(double rum);
+  void setRum(unsigned int rum);
 
-  double getMaxRum() const;
+  unsigned int getMaxRum() const;
 
-  void setMaxRum(double max_rum);
+  void setMaxRum(unsigned int max_rum);
 
   double getRumRate() const;
 
   void setRumRate(double rum_rate);
 
-  double getRumPrice() const;
+  unsigned int getRumPrice() const;
 
   bool const isBuyPort() const;
 
@@ -44,33 +44,36 @@ public:
 
 private:
 
-  double rum;
+  unsigned int rum;
 
-  double max_rum;
+  unsigned int max_rum;
 
   double rum_rate;
 
   // The name of this port
   std::string name;
+
+  // How long it has been since the rum count last changed
+  double rum_time;
   
 };
 
-inline double Port::getRum() const
+inline unsigned int Port::getRum() const
 {
   return rum;
 }
 
-inline void Port::setRum(double rum)
+inline void Port::setRum(unsigned int rum)
 {
   this->rum = rum;
 }
 
-inline double Port::getMaxRum() const
+inline unsigned int Port::getMaxRum() const
 {
   return max_rum;
 }
 
-inline void Port::setMaxRum(double max_rum)
+inline void Port::setMaxRum(unsigned int max_rum)
 {
   this->max_rum = max_rum;
 }
@@ -85,7 +88,7 @@ inline void Port::setRumRate(double rum_rate)
   this->rum_rate = rum_rate;
 }
 
-inline double Port::getRumPrice() const
+inline unsigned int Port::getRumPrice() const
 {
   return std::min(max_rum - rum + 1.0, 10.0);
 }

--- a/code/include/Ship.hpp
+++ b/code/include/Ship.hpp
@@ -18,17 +18,17 @@ public:
 
   virtual void update(const sf::Time& delta_t);
 
-  double getGold() const;
+  unsigned int getGold() const;
 
-  void setGold(double gold);
+  void setGold(unsigned int gold);
 
-  double getRum() const;
+  unsigned int getRum() const;
 
-  void setRum(double rum);
+  void setRum(unsigned int rum);
 
-  double getMaxRum() const;
+  unsigned int getMaxRum() const;
 
-  void setMaxRum(double max_rum);
+  void setMaxRum(unsigned int max_rum);
 
   double getRumRate() const;
 
@@ -36,42 +36,43 @@ public:
 
 private:
 
-  double gold;
+  unsigned int gold;
 
-  double rum;
+  unsigned int rum;
 
-  double max_rum;
+  unsigned int max_rum;
 
   double rum_rate;
   
+  double rum_time;
 };
 
-inline double Ship::getGold() const
+inline unsigned int Ship::getGold() const
 {
   return gold;
 }
 
-inline void Ship::setGold(double gold)
+inline void Ship::setGold(unsigned int gold)
 {
   this->gold = gold;
 }
 
-inline double Ship::getRum() const
+inline unsigned int Ship::getRum() const
 {
   return rum;
 }
 
-inline void Ship::setRum(double rum)
+inline void Ship::setRum(unsigned int rum)
 {
   this->rum = rum;
 }
 
-inline double Ship::getMaxRum() const
+inline unsigned int Ship::getMaxRum() const
 {
   return max_rum;
 }
 
-inline void Ship::setMaxRum(double max_rum)
+inline void Ship::setMaxRum(unsigned int max_rum)
 {
   this->max_rum = max_rum;
 }
@@ -84,6 +85,10 @@ inline double Ship::getRumRate() const
 inline void Ship::setRumRate(double rum_rate)
 {
   this->rum_rate = rum_rate;
+
+  // We want to do this to avoid massive rum changes when changing from a low
+  // rum rate to a high rum rate
+  rum_time = 0.0;
 }
 
 #endif

--- a/code/include/TransactionCheckEvent.hpp
+++ b/code/include/TransactionCheckEvent.hpp
@@ -13,7 +13,12 @@ public:
 
   TransactionCheckEvent();
 
-  TransactionCheckEvent(ActorId ship_id, ActorId port_id, double ship_gold, double ship_rum, double port_rum, double rum_request);
+  TransactionCheckEvent(ActorId ship_id,
+			ActorId port_id,
+			unsigned int ship_gold,
+			unsigned int ship_rum,
+			unsigned int port_rum,
+			unsigned int rum_request);
 
   virtual ~TransactionCheckEvent();
 
@@ -32,28 +37,28 @@ public:
   ActorId getPortId() const;
 
   /* Ship gold setter */
-  void setShipGold(double x);
+  void setShipGold(unsigned int x);
 
   /* Ship gold getter */
-  double getShipGold() const;
+  unsigned int getShipGold() const;
 
   /* Ship rum setter */
-  void setShipRum(double y);
+  void setShipRum(unsigned int y);
 
   /* Ship rum getter */
-  double getShipRum() const;
+  unsigned int getShipRum() const;
   
   /* Port rum setter */
-  void setPortRum(double y);
+  void setPortRum(unsigned int y);
 
   /* Port rum getter */
-  double getPortRum() const;
+  unsigned int getPortRum() const;
   
   /* Request Rum setter */
-  void setRumRequest(double y);
+  void setRumRequest(unsigned int y);
 
   /* Request Rum getter*/
-  double getRumRequest() const;
+  unsigned int getRumRequest() const;
 
   /* TransactionCheckEvent's event type */
   static const EventType event_type;
@@ -64,10 +69,10 @@ private:
   ActorId ship_id, port_id;
 
   /* Rum and gold of actors associated with this event */
-  double ship_gold;
-  double ship_rum;
-  double port_rum;
-  double rum_request;
+  unsigned int ship_gold;
+  unsigned int ship_rum;
+  unsigned int port_rum;
+  unsigned int rum_request;
 };
 
 inline EventType TransactionCheckEvent::getEventType() const
@@ -95,42 +100,42 @@ inline ActorId TransactionCheckEvent::getPortId() const
   return port_id;
 }
 
-inline void TransactionCheckEvent::setShipGold(double x)
+inline void TransactionCheckEvent::setShipGold(unsigned int x)
 {
   this->ship_gold = x;
 }
 
-inline double TransactionCheckEvent::getShipGold() const
+inline unsigned int TransactionCheckEvent::getShipGold() const
 {
   return ship_gold;
 }
 
-inline void TransactionCheckEvent::setShipRum(double y)
+inline void TransactionCheckEvent::setShipRum(unsigned int y)
 {
   this->ship_rum = y;
 }
 
-inline double TransactionCheckEvent::getShipRum() const
+inline unsigned int TransactionCheckEvent::getShipRum() const
 {
   return ship_rum;
 }
 
-inline void TransactionCheckEvent::setPortRum(double y)
+inline void TransactionCheckEvent::setPortRum(unsigned int y)
 {
   this->port_rum= y;
 }
 
-inline double TransactionCheckEvent::getPortRum() const
+inline unsigned int TransactionCheckEvent::getPortRum() const
 {
   return port_rum;
 }
 
-inline void TransactionCheckEvent::setRumRequest(double y)
+inline void TransactionCheckEvent::setRumRequest(unsigned int y)
 {
   this->rum_request= y;
 }
 
-inline double TransactionCheckEvent::getRumRequest() const
+inline unsigned int TransactionCheckEvent::getRumRequest() const
 {
   return rum_request;
 }

--- a/code/include/TransactionFailEvent.hpp
+++ b/code/include/TransactionFailEvent.hpp
@@ -13,7 +13,11 @@ public:
 
   TransactionFailEvent();
 
-  TransactionFailEvent(ActorId ship_id, ActorId port_id, double ship_gold, double ship_rum, double port_rum);
+  TransactionFailEvent(ActorId ship_id,
+		       ActorId port_id,
+		       unsigned int ship_gold,
+		       unsigned int ship_rum,
+		       unsigned int port_rum);
 
   virtual ~TransactionFailEvent();
 
@@ -32,22 +36,22 @@ public:
   ActorId getPortId() const;
 
   /* Ship gold setter */
-  void setShipGold(double x);
+  void setShipGold(unsigned int x);
 
   /* Ship gold getter */
-  double getShipGold() const;
+  unsigned int getShipGold() const;
 
   /* Ship rum setter */
-  void setShipRum(double y);
+  void setShipRum(unsigned int y);
 
   /* Ship rum getter */
-  double getShipRum() const;
+  unsigned int getShipRum() const;
   
   /* Port rum setter */
-  void setPortRum(double y);
+  void setPortRum(unsigned int y);
 
   /* Port rum getter */
-  double getPortRum() const;
+  unsigned int getPortRum() const;
 
   /* TransactionFailEvent's event type */
   static const EventType event_type;
@@ -58,9 +62,9 @@ private:
   ActorId ship_id, port_id;
 
   /* Rum and gold of actors associated with this event */
-  double ship_gold;
-  double ship_rum;
-  double port_rum;
+  unsigned int ship_gold;
+  unsigned int ship_rum;
+  unsigned int port_rum;
 };
 
 inline EventType TransactionFailEvent::getEventType() const
@@ -88,32 +92,32 @@ inline ActorId TransactionFailEvent::getPortId() const
   return port_id;
 }
 
-inline void TransactionFailEvent::setShipGold(double x)
+inline void TransactionFailEvent::setShipGold(unsigned int x)
 {
   this->ship_gold = x;
 }
 
-inline double TransactionFailEvent::getShipGold() const
+inline unsigned int TransactionFailEvent::getShipGold() const
 {
   return ship_gold;
 }
 
-inline void TransactionFailEvent::setShipRum(double y)
+inline void TransactionFailEvent::setShipRum(unsigned int y)
 {
   this->ship_rum = y;
 }
 
-inline double TransactionFailEvent::getShipRum() const
+inline unsigned int TransactionFailEvent::getShipRum() const
 {
   return ship_rum;
 }
 
-inline void TransactionFailEvent::setPortRum(double y)
+inline void TransactionFailEvent::setPortRum(unsigned int y)
 {
   this->port_rum= y;
 }
 
-inline double TransactionFailEvent::getPortRum() const
+inline unsigned int TransactionFailEvent::getPortRum() const
 {
   return port_rum;
 }

--- a/code/include/TransactionStartEvent.hpp
+++ b/code/include/TransactionStartEvent.hpp
@@ -13,11 +13,11 @@ public:
 
   TransactionStartEvent();
 
-  TransactionStartEvent(ActorId ship_id,
-			ActorId port_id,
-			double ship_gold,
-			double ship_rum,
-			double port_rum);
+  TransactionStartEvent(ActorId      ship_id,
+			ActorId      port_id,
+			unsigned int ship_gold,
+			unsigned int ship_rum,
+			unsigned int port_rum);
 
   virtual ~TransactionStartEvent();
 
@@ -36,22 +36,22 @@ public:
   ActorId getPortId() const;
 
   /* Ship gold setter */
-  void setShipGold(double x);
+  void setShipGold(unsigned int x);
 
   /* Ship gold getter */
-  double getShipGold() const;
+  unsigned int getShipGold() const;
 
   /* Ship rum setter */
-  void setShipRum(double y);
+  void setShipRum(unsigned int y);
 
   /* Ship rum getter */
-  double getShipRum() const;
+  unsigned int getShipRum() const;
   
   /* Port rum setter */
-  void setPortRum(double y);
+  void setPortRum(unsigned int y);
 
   /* Port rum getter */
-  double getPortRum() const;
+  unsigned int getPortRum() const;
 
   /* TransactionStartEvent's event type */
   static const EventType event_type;
@@ -62,9 +62,9 @@ private:
   ActorId ship_id, port_id;
 
   /* Rum and gold of actors associated with this event */
-  double ship_gold;
-  double ship_rum;
-  double port_rum;
+  unsigned int ship_gold;
+  unsigned int ship_rum;
+  unsigned int port_rum;
 };
 
 inline EventType TransactionStartEvent::getEventType() const
@@ -92,32 +92,32 @@ inline ActorId TransactionStartEvent::getPortId() const
   return port_id;
 }
 
-inline void TransactionStartEvent::setShipGold(double x)
+inline void TransactionStartEvent::setShipGold(unsigned int x)
 {
   this->ship_gold = x;
 }
 
-inline double TransactionStartEvent::getShipGold() const
+inline unsigned int TransactionStartEvent::getShipGold() const
 {
   return ship_gold;
 }
 
-inline void TransactionStartEvent::setShipRum(double y)
+inline void TransactionStartEvent::setShipRum(unsigned int y)
 {
   this->ship_rum = y;
 }
 
-inline double TransactionStartEvent::getShipRum() const
+inline unsigned int TransactionStartEvent::getShipRum() const
 {
   return ship_rum;
 }
 
-inline void TransactionStartEvent::setPortRum(double y)
+inline void TransactionStartEvent::setPortRum(unsigned int y)
 {
   this->port_rum= y;
 }
 
-inline double TransactionStartEvent::getPortRum() const
+inline unsigned int TransactionStartEvent::getPortRum() const
 {
   return port_rum;
 }

--- a/code/include/TransactionSuccessEvent.hpp
+++ b/code/include/TransactionSuccessEvent.hpp
@@ -13,7 +13,11 @@ public:
 
   TransactionSuccessEvent();
 
-  TransactionSuccessEvent(ActorId ship_id, ActorId port_id, double ship_gold, double ship_rum, double port_rum);
+  TransactionSuccessEvent(ActorId ship_id,
+			  ActorId port_id,
+			  unsigned int ship_gold,
+			  unsigned int ship_rum,
+			  unsigned int port_rum);
 
   virtual ~TransactionSuccessEvent();
 
@@ -32,22 +36,22 @@ public:
   ActorId getPortId() const;
 
   /* Ship gold setter */
-  void setShipGold(double x);
+  void setShipGold(unsigned int x);
 
   /* Ship gold getter */
-  double getShipGold() const;
+  unsigned int getShipGold() const;
 
   /* Ship rum setter */
-  void setShipRum(double y);
+  void setShipRum(unsigned int y);
 
   /* Ship rum getter */
-  double getShipRum() const;
+  unsigned int getShipRum() const;
   
   /* Port rum setter */
-  void setPortRum(double y);
+  void setPortRum(unsigned int y);
 
   /* Port rum getter */
-  double getPortRum() const;
+  unsigned int getPortRum() const;
 
   /* TransactionSuccessEvent's event type */
   static const EventType event_type;
@@ -58,9 +62,9 @@ private:
   ActorId ship_id, port_id;
 
   /* Rum and gold of actors associated with this event */
-  double ship_gold;
-  double ship_rum;
-  double port_rum;
+  unsigned int ship_gold;
+  unsigned int ship_rum;
+  unsigned int port_rum;
 };
 
 inline EventType TransactionSuccessEvent::getEventType() const
@@ -88,32 +92,32 @@ inline ActorId TransactionSuccessEvent::getPortId() const
   return port_id;
 }
 
-inline void TransactionSuccessEvent::setShipGold(double x)
+inline void TransactionSuccessEvent::setShipGold(unsigned int x)
 {
   this->ship_gold = x;
 }
 
-inline double TransactionSuccessEvent::getShipGold() const
+inline unsigned int TransactionSuccessEvent::getShipGold() const
 {
   return ship_gold;
 }
 
-inline void TransactionSuccessEvent::setShipRum(double y)
+inline void TransactionSuccessEvent::setShipRum(unsigned int y)
 {
   this->ship_rum = y;
 }
 
-inline double TransactionSuccessEvent::getShipRum() const
+inline unsigned int TransactionSuccessEvent::getShipRum() const
 {
   return ship_rum;
 }
 
-inline void TransactionSuccessEvent::setPortRum(double y)
+inline void TransactionSuccessEvent::setPortRum(unsigned int y)
 {
   this->port_rum= y;
 }
 
-inline double TransactionSuccessEvent::getPortRum() const
+inline unsigned int TransactionSuccessEvent::getPortRum() const
 {
   return port_rum;
 }

--- a/code/src/GameLogic.cpp
+++ b/code/src/GameLogic.cpp
@@ -254,7 +254,7 @@ void GameLogic::ShipMoveCmdEventHandler(const EventInterface& event)
 void GameLogic::TransactionCheckEventHandler(const EventInterface& event)
 {
   unsigned int shipid, portid, price, rum=1;
-  double shipgold, shiprum, shipmaxrum, portrum, rumrequest;
+  unsigned int shipgold, shiprum, shipmaxrum, portrum, rumrequest;
 
   const TransactionCheckEvent* tcheck_event =
     dynamic_cast<const TransactionCheckEvent*>(&event);
@@ -275,12 +275,15 @@ void GameLogic::TransactionCheckEventHandler(const EventInterface& event)
   
   price = ports[portid]->getRumPrice();
   
-  if (ports[portid]->isBuyPort() && rumrequest + shiprum <= shipmaxrum && rumrequest <= portrum && rumrequest * price <= shipgold)
+  if (ports[portid]->isBuyPort() &&
+      rumrequest + shiprum <= shipmaxrum &&
+      rumrequest <= portrum &&
+      rumrequest * price <= shipgold)
   {
-      ship->setGold(shipgold - (price * rumrequest));
-	  ship->setRum(shiprum + rumrequest);
-	  ports[portid]->setRum(portrum - rumrequest);
-	  // This transaction succeeds so signal that with the TransactionSuccessEvent
+    ship->setGold(shipgold - (price * rumrequest));
+    ship->setRum(shiprum + rumrequest);
+    ports[portid]->setRum(portrum - rumrequest);
+    // This transaction succeeds so signal that with the TransactionSuccessEvent
     TransactionSuccessEvent* tsuccess_event =
       new TransactionSuccessEvent(ship->getActorId(),
 				  portid,
@@ -293,10 +296,10 @@ void GameLogic::TransactionCheckEventHandler(const EventInterface& event)
   }
   else if (!ports[portid]->isBuyPort() && rumrequest <= shiprum)
   {
-      ship->setGold(shipgold + (price * rumrequest));
-	  ship->setRum(shiprum - rumrequest);
-	  ports[portid]->setRum(portrum + rumrequest);
-	  // This transaction succeeds so signal that with the TransactionSuccessEvent
+    ship->setGold(shipgold + (price * rumrequest));
+    ship->setRum(shiprum - rumrequest);
+    ports[portid]->setRum(portrum + rumrequest);
+    // This transaction succeeds so signal that with the TransactionSuccessEvent
     TransactionSuccessEvent* tsuccess_event =
       new TransactionSuccessEvent(ship->getActorId(),
 				  portid,

--- a/code/src/Port.cpp
+++ b/code/src/Port.cpp
@@ -33,8 +33,18 @@ void Port::update(const sf::Time& delta_t)
     return;
   }
    
-  // Track how much time has passed since the last rum count change
-  rum_time += delta_t.asSeconds();
+  // Track how much time has passed since the last rum count change, unless rum
+  // is up against its limit or rum amount isn't changing
+  if ((rum == 0 && rum_rate < 0.0) ||
+      (rum == max_rum && rum_rate > 0.0) ||
+      rum_rate == 0.0)
+  {
+    rum_time = 0.0;
+  }
+  else
+  {
+    rum_time += delta_t.asSeconds();
+  }
 
   // Should the rum amount change this frame?
   if (rum_rate != 0.0 && rum_time > std::abs(1.0 / rum_rate))
@@ -42,9 +52,6 @@ void Port::update(const sf::Time& delta_t)
     // How much should be adjust the rum amount by?
     unsigned int delta_rum_abs =
       static_cast<unsigned int>(std::trunc(std::abs(rum_time * rum_rate)));
-
-    // Will be set true below if rum reaches a lower or upper limit
-    bool limit_reached = false;
 
     // Will the change be positive or negative?
     if (rum_rate > 0.0)
@@ -56,8 +63,6 @@ void Port::update(const sf::Time& delta_t)
       {
 	// Cap it so it doesn't exceed max_rum
 	delta_rum_abs = max_rum - rum;
-
-	limit_reached = true;
       }
 
       // Add the delta to the current rum amount
@@ -70,8 +75,6 @@ void Port::update(const sf::Time& delta_t)
       {
 	// Cap it so it doesn't underflow
 	delta_rum_abs = rum;
-
-	limit_reached = true;
       }
 
       // Subtract the delta from the current rum amount
@@ -81,15 +84,6 @@ void Port::update(const sf::Time& delta_t)
     // We just adjusted the rum by delta_rum_abs, so now we need to subtract
     // from rum_time the amount of time it takes at the current rum rate to
     // accumulate delta_rum_abs amount of rum change.
-    if (limit_reached)
-    {
-      // We hit a rum limit.  Zero rum_time to avoid large build-ups of rum
-      // time at the limit
-      rum_time = 0.0;
-    }
-    else
-    {
-      rum_time -= static_cast<double>(delta_rum_abs) / std::abs(rum_rate);
-    }
+    rum_time -= static_cast<double>(delta_rum_abs) / std::abs(rum_rate);
   }
 }

--- a/code/src/Port.cpp
+++ b/code/src/Port.cpp
@@ -34,8 +34,20 @@ void Port::update(const sf::Time& delta_t)
     return;
   }
    
-  // Track how much time has passed since the last rum count change
-  rum_time += delta_t.asSeconds();
+  // Track how much time has passed since the last rum count change, unless
+  // we're up against a rum limit, in which case set rum_time to 0.  This
+  // disables the accumulation of rum_time while at a limit.  If this isn't
+  // done, massive rum times accumulate while rum is at the limit, which leads
+  // to massive rum changes when the rum amount comes off the limit (after a
+  // transaction for example).
+  if (rum == 0 || rum == max_rum)
+  {
+    rum_time = 0.0;
+  }
+  else
+  {
+    rum_time += delta_t.asSeconds();
+  }
 
   // Should the rum amount change this frame?
   if (rum_rate != 0.0 && rum_time > std::abs(1.0 / rum_rate))
@@ -47,12 +59,17 @@ void Port::update(const sf::Time& delta_t)
     // Will the change be positive or negative?
     if (rum_rate > 0.0)
     {
-      // Will this overflow?
-      if (delta_rum_abs > std::numeric_limits<unsigned int>::max() - rum)
+      // Will this change exceed max_rum?  Incidentally if there were no
+      // max_rum, this would be where you would cap to avoid overflow on the rum
+      // variable
+      if (delta_rum_abs > max_rum - rum)
       {
-	// Cap it so it doesn't overflow
-	delta_rum_abs = std::numeric_limits<unsigned int>::max() - rum;
+	// Cap it so it doesn't exceed max_rum
+	delta_rum_abs = max_rum - rum;
       }
+
+      // Add the delta to the current rum amount
+      rum += delta_rum_abs;
     }
     else
     {
@@ -62,17 +79,14 @@ void Port::update(const sf::Time& delta_t)
 	// Cap it so it doesn't underflow
 	delta_rum_abs = rum;
       }
+
+      // Subtract the delta from the current rum amount
+      rum -= delta_rum_abs;
     }
 
-    // Perform the adjustment, capping at max_rum
-    /*rum += delta_rum;
-    rum = std::min(rum, max_rum);
-
-
-    //fail-safe to prevent rum from exceeding max or min
-    if(rum < 0.0)
-	rum = 0.0;
-    if(rum > max_rum)
-    rum = max_rum;*/
+    // We just adjusted the rum by delta_rum_abs, so now we need to subtract
+    // from rum_time the amount of time it takes at the current rum rate to
+    // accumulate delta_rum_abs amount of rum change.
+    rum_time -= static_cast<double>(delta_rum_abs) / std::abs(rum_rate);
   }
 }

--- a/code/src/Port.cpp
+++ b/code/src/Port.cpp
@@ -1,7 +1,6 @@
 #include <SFML/System/Time.hpp>
 #include <cmath>
 #include <cstdlib>
-#include <limits>
 
 #include "ActorId.hpp"
 #include "Port.hpp"

--- a/code/src/Port.cpp
+++ b/code/src/Port.cpp
@@ -38,23 +38,30 @@ void Port::update(const sf::Time& delta_t)
   rum_time += delta_t.asSeconds();
 
   // Should the rum amount change this frame?
-  if (rum_time > std::abs(1.0 / rum_rate))
+  if (rum_rate != 0.0 && rum_time > std::abs(1.0 / rum_rate))
   {
     // How much should be adjust the rum amount by?
-    int delta_rum = static_cast<int>(std::trunc(rum_time * rum_rate));
+    unsigned int delta_rum_abs =
+      static_cast<unsigned int>(std::trunc(std::abs(rum_time * rum_rate)));
 
-    // Would this adjustment cause a rum overflow or underflow?  You can't
-    // actually perform the modification to test because that would cause the
-    // condition we're trying to test for
-    if (delta_rum < 0 && std::abs(delta_rum) > rum)
+    // Will the change be positive or negative?
+    if (rum_rate > 0.0)
     {
-      // This would underflow, so just set delta_rum so it zeros rum
-      delta_rum = -static_cast<int>(rum);
+      // Will this overflow?
+      if (delta_rum_abs > std::numeric_limits<unsigned int>::max() - rum)
+      {
+	// Cap it so it doesn't overflow
+	delta_rum_abs = std::numeric_limits<unsigned int>::max() - rum;
+      }
     }
-    else if (delta_rum > std::numeric_limits<unsigned int>::max() - rum)
+    else
     {
-      // This would overflow, so just set delta_rum so it maxes out rum
-      delta_rum = std::numeric_limits<unsigned int>::max() - rum;
+      // Will this underflow?
+      if (delta_rum_abs > rum)
+      {
+	// Cap it so it doesn't underflow
+	delta_rum_abs = rum;
+      }
     }
 
     // Perform the adjustment, capping at max_rum

--- a/code/src/Port.cpp
+++ b/code/src/Port.cpp
@@ -1,13 +1,17 @@
 #include <SFML/System/Time.hpp>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
 
 #include "ActorId.hpp"
 #include "Port.hpp"
 
 Port::Port(ActorId actor_id) :
   Actor(actor_id),
-  rum(0.0),
-  max_rum(10.0),
-  rum_rate(1.0)
+  rum(0),
+  max_rum(10),
+  rum_rate(1.0),
+  rum_time(0)
 {
 }
 
@@ -23,9 +27,40 @@ bool Port::initialize()
 void Port::update(const sf::Time& delta_t)
 {
   Actor::update(delta_t);
-  if(delta_t.asSeconds() != 0.0)
+
+  // If no time has passed since the last update just leave
+  if(delta_t.asSeconds() == 0.0)
   {
-    rum += rum_rate*delta_t.asSeconds();
+    return;
+  }
+   
+  // Track how much time has passed since the last rum count change
+  rum_time += delta_t.asSeconds();
+
+  // Should the rum amount change this frame?
+  if (rum_time > std::abs(1.0 / rum_rate))
+  {
+    // How much should be adjust the rum amount by?
+    int delta_rum = static_cast<int>(std::trunc(rum_time / rum_rate));
+
+    // Would this adjustment cause a rum overflow or underflow?  You can't
+    // actually perform the modification to test because that would cause the
+    // condition we're trying to test for
+    if (delta_rum < 0 && std::abs(delta_rum) > rum)
+    {
+      // This would underflow, so just set delta_rum so it zeros rum
+      delta_rum = -static_cast<int>(rum);
+    }
+    else if (delta_rum > std::numeric_limits<int>::max() - rum)
+    {
+      // This would overflow, so just set delta_rum so it maxes out rum
+      delta_rum = std::numeric_limits<int>::max() - rum;
+    }
+
+    // Perform the adjustment, capping at max_rum
+    rum += delta_rum;
+    rum = std::min(rum, max_rum);
+
 
     //fail-safe to prevent rum from exceeding max or min
     if(rum < 0.0)

--- a/code/src/Port.cpp
+++ b/code/src/Port.cpp
@@ -41,7 +41,7 @@ void Port::update(const sf::Time& delta_t)
   if (rum_time > std::abs(1.0 / rum_rate))
   {
     // How much should be adjust the rum amount by?
-    int delta_rum = static_cast<int>(std::trunc(rum_time / rum_rate));
+    int delta_rum = static_cast<int>(std::trunc(rum_time * rum_rate));
 
     // Would this adjustment cause a rum overflow or underflow?  You can't
     // actually perform the modification to test because that would cause the
@@ -51,14 +51,14 @@ void Port::update(const sf::Time& delta_t)
       // This would underflow, so just set delta_rum so it zeros rum
       delta_rum = -static_cast<int>(rum);
     }
-    else if (delta_rum > std::numeric_limits<int>::max() - rum)
+    else if (delta_rum > std::numeric_limits<unsigned int>::max() - rum)
     {
       // This would overflow, so just set delta_rum so it maxes out rum
-      delta_rum = std::numeric_limits<int>::max() - rum;
+      delta_rum = std::numeric_limits<unsigned int>::max() - rum;
     }
 
     // Perform the adjustment, capping at max_rum
-    rum += delta_rum;
+    /*rum += delta_rum;
     rum = std::min(rum, max_rum);
 
 
@@ -66,6 +66,6 @@ void Port::update(const sf::Time& delta_t)
     if(rum < 0.0)
 	rum = 0.0;
     if(rum > max_rum)
-	rum = max_rum;
+    rum = max_rum;*/
   }
 }

--- a/code/src/Ship.cpp
+++ b/code/src/Ship.cpp
@@ -33,9 +33,19 @@ void Ship::update(const sf::Time& delta_t)
   {
     return;
   }
-   
-  // Track how much time has passed since the last rum count change
-  rum_time += delta_t.asSeconds();
+
+  // Track how much time has passed since the last rum count change, unless rum
+  // is up against its limit or rum amount isn't changing
+  if ((rum == 0 && rum_rate < 0.0) ||
+      (rum == max_rum && rum_rate > 0.0) ||
+      rum_rate == 0.0)
+  {
+    rum_time = 0.0;
+  }
+  else
+  {
+    rum_time += delta_t.asSeconds();
+  }
 
   // Should the rum amount change this frame?
   if (rum_rate != 0.0 && rum_time > std::abs(1.0 / rum_rate))
@@ -43,9 +53,6 @@ void Ship::update(const sf::Time& delta_t)
     // How much should be adjust the rum amount by?
     unsigned int delta_rum_abs =
       static_cast<unsigned int>(std::trunc(std::abs(rum_time * rum_rate)));
-
-    // Will be set true below if rum reaches a lower or upper limit
-    bool limit_reached = false;
 
     // Will the change be positive or negative?
     if (rum_rate > 0.0)
@@ -57,8 +64,6 @@ void Ship::update(const sf::Time& delta_t)
       {
 	// Cap it so it doesn't exceed max_rum
 	delta_rum_abs = max_rum - rum;
-
-	limit_reached = true;
       }
 
       // Add the delta to the current rum amount
@@ -71,8 +76,6 @@ void Ship::update(const sf::Time& delta_t)
       {
 	// Cap it so it doesn't underflow
 	delta_rum_abs = rum;
-
-	limit_reached = true;
       }
 
       // Subtract the delta from the current rum amount
@@ -82,15 +85,6 @@ void Ship::update(const sf::Time& delta_t)
     // We just adjusted the rum by delta_rum_abs, so now we need to subtract
     // from rum_time the amount of time it takes at the current rum rate to
     // accumulate delta_rum_abs amount of rum change.
-    if (limit_reached)
-    {
-      // We hit a rum limit.  Zero rum_time to avoid large build-ups of rum
-      // time at the limit
-      rum_time = 0.0;
-    }
-    else
-    {
-      rum_time -= static_cast<double>(delta_rum_abs) / std::abs(rum_rate);
-    }
+    rum_time -= static_cast<double>(delta_rum_abs) / std::abs(rum_rate);
   }
 }

--- a/code/src/Ship.cpp
+++ b/code/src/Ship.cpp
@@ -1,14 +1,17 @@
 #include <SFML/System/Time.hpp>
+#include <cmath>
+#include <cstdlib>
 
 #include "ActorId.hpp"
 #include "Ship.hpp"
 
 Ship::Ship(ActorId actor_id) :
   Actor(actor_id),
-  gold(0.0),
-  rum(0.0),
-  max_rum(10.0),
-  rum_rate(1.0)
+  gold(0),
+  rum(0),
+  max_rum(10),
+  rum_rate(1.0),
+  rum_time(0.0)
 {
 }
 
@@ -24,13 +27,70 @@ bool Ship::initialize()
 void Ship::update(const sf::Time& delta_t)
 {
   Actor::update(delta_t);
-  if(delta_t.asSeconds() != 0.0)
-  {
-    rum += rum_rate*delta_t.asSeconds();
 
-    if(rum < 0.0)
-      rum = 0.0;
-    if(rum > max_rum)
-      rum = max_rum;
+  // If no time has passed since the last update just leave
+  if(delta_t.asSeconds() == 0.0)
+  {
+    return;
+  }
+   
+  // Track how much time has passed since the last rum count change
+  rum_time += delta_t.asSeconds();
+
+  // Should the rum amount change this frame?
+  if (rum_rate != 0.0 && rum_time > std::abs(1.0 / rum_rate))
+  {
+    // How much should be adjust the rum amount by?
+    unsigned int delta_rum_abs =
+      static_cast<unsigned int>(std::trunc(std::abs(rum_time * rum_rate)));
+
+    // Will be set true below if rum reaches a lower or upper limit
+    bool limit_reached = false;
+
+    // Will the change be positive or negative?
+    if (rum_rate > 0.0)
+    {
+      // Will this change exceed max_rum?  Incidentally if there were no
+      // max_rum, this would be where you would cap to avoid overflow on the rum
+      // variable
+      if (delta_rum_abs > max_rum - rum)
+      {
+	// Cap it so it doesn't exceed max_rum
+	delta_rum_abs = max_rum - rum;
+
+	limit_reached = true;
+      }
+
+      // Add the delta to the current rum amount
+      rum += delta_rum_abs;
+    }
+    else
+    {
+      // Will this underflow?
+      if (delta_rum_abs > rum)
+      {
+	// Cap it so it doesn't underflow
+	delta_rum_abs = rum;
+
+	limit_reached = true;
+      }
+
+      // Subtract the delta from the current rum amount
+      rum -= delta_rum_abs;
+    }
+
+    // We just adjusted the rum by delta_rum_abs, so now we need to subtract
+    // from rum_time the amount of time it takes at the current rum rate to
+    // accumulate delta_rum_abs amount of rum change.
+    if (limit_reached)
+    {
+      // We hit a rum limit.  Zero rum_time to avoid large build-ups of rum
+      // time at the limit
+      rum_time = 0.0;
+    }
+    else
+    {
+      rum_time -= static_cast<double>(delta_rum_abs) / std::abs(rum_rate);
+    }
   }
 }

--- a/code/src/TransactionCheckEvent.cpp
+++ b/code/src/TransactionCheckEvent.cpp
@@ -18,14 +18,19 @@ TransactionCheckEvent::TransactionCheckEvent() :
 {
 }
 
-TransactionCheckEvent::TransactionCheckEvent(ActorId ship_id, ActorId port_id, double ship_gold, double ship_rum, double port_rum, double rum_request)
+TransactionCheckEvent::TransactionCheckEvent(ActorId ship_id,
+					     ActorId port_id,
+					     unsigned int ship_gold,
+					     unsigned int ship_rum,
+					     unsigned int port_rum,
+					     unsigned int rum_request)
   : EventInterface(),
     ship_id(ship_id),
     port_id(port_id),
     ship_gold(ship_gold),
     ship_rum(ship_rum),
     port_rum(port_rum),
-	rum_request(rum_request)
+    rum_request(rum_request)
 {
 }
 

--- a/code/src/TransactionFailEvent.cpp
+++ b/code/src/TransactionFailEvent.cpp
@@ -17,7 +17,11 @@ TransactionFailEvent::TransactionFailEvent() :
 {
 }
 
-TransactionFailEvent::TransactionFailEvent(ActorId ship_id, ActorId port_id, double ship_gold, double ship_rum, double port_rum)
+TransactionFailEvent::TransactionFailEvent(ActorId ship_id,
+					   ActorId port_id,
+					   unsigned int ship_gold,
+					   unsigned int ship_rum,
+					   unsigned int port_rum)
   : EventInterface(),
     ship_id(ship_id),
     port_id(port_id),

--- a/code/src/TransactionStartEvent.cpp
+++ b/code/src/TransactionStartEvent.cpp
@@ -17,7 +17,11 @@ TransactionStartEvent::TransactionStartEvent() :
 {
 }
 
-TransactionStartEvent::TransactionStartEvent(ActorId ship_id, ActorId port_id, double ship_gold, double ship_rum, double port_rum)
+TransactionStartEvent::TransactionStartEvent(ActorId ship_id,
+					     ActorId port_id,
+					     unsigned int ship_gold,
+					     unsigned int ship_rum,
+					     unsigned int port_rum)
   : EventInterface(),
     ship_id(ship_id),
     port_id(port_id),

--- a/code/src/TransactionSuccessEvent.cpp
+++ b/code/src/TransactionSuccessEvent.cpp
@@ -17,7 +17,11 @@ TransactionSuccessEvent::TransactionSuccessEvent() :
 {
 }
 
-TransactionSuccessEvent::TransactionSuccessEvent(ActorId ship_id, ActorId port_id, double ship_gold, double ship_rum, double port_rum)
+TransactionSuccessEvent::TransactionSuccessEvent(ActorId ship_id,
+						 ActorId port_id,
+						 unsigned int ship_gold,
+						 unsigned int ship_rum,
+						 unsigned int port_rum)
   : EventInterface(),
     ship_id(ship_id),
     port_id(port_id),


### PR DESCRIPTION
Rum and gold amounts are now stored as unsigned integers, rather than doubles as they were previously.  This gets rid of those strange rounding issues with the UI and also conceptually matches how we think of rum and gold (in integer amounts).  I'm pretty sure I got everything changed over but if I missed something let me know.

The ports and the ship use the exact same code, duplicated in their respective update functions, to change their rum amounts.  That's less than ideal but it works.  It could be in a common base class or a "component" as described in lecture long ago, but eh, that's more work.

Resolves #48.
