### PR TITLE
Transaction window price

### DIFF
--- a/code/include/HumanGameView.hpp
+++ b/code/include/HumanGameView.hpp
@@ -122,6 +122,7 @@ private:
   int tc_shipgold;
   int tc_shiprum;
   int tc_portrum;
+  unsigned int tc_rum_price;
 };
 
 inline unsigned int HumanGameView::getMapTileSize() const

--- a/code/include/TransactionStartEvent.hpp
+++ b/code/include/TransactionStartEvent.hpp
@@ -17,7 +17,8 @@ public:
 			ActorId port_id,
 			double ship_gold,
 			double ship_rum,
-			double port_rum);
+			double port_rum,
+			unsigned int port_price);
 
   virtual ~TransactionStartEvent();
 
@@ -53,6 +54,10 @@ public:
   /* Port rum getter */
   double getPortRum() const;
 
+  void setRumPrice(unsigned int rum_price);
+
+  unsigned int getRumPrice() const;
+
   /* TransactionStartEvent's event type */
   static const EventType event_type;
 
@@ -65,6 +70,7 @@ private:
   double ship_gold;
   double ship_rum;
   double port_rum;
+  unsigned int rum_price;
 };
 
 inline EventType TransactionStartEvent::getEventType() const
@@ -122,5 +128,14 @@ inline double TransactionStartEvent::getPortRum() const
   return port_rum;
 }
 
+inline void TransactionStartEvent::setRumPrice(unsigned int rum_price)
+{
+  this->rum_price = rum_price;
+}
+
+inline unsigned int TransactionStartEvent::getRumPrice() const
+{
+  return rum_price;
+}
 
 #endif

--- a/code/src/GameLogic.cpp
+++ b/code/src/GameLogic.cpp
@@ -244,6 +244,7 @@ void GameLogic::ShipMoveCmdEventHandler(const EventInterface& event)
 	ts_event->setShipRum(ship->getRum());
 	ts_event->setPortId(i->second->getActorId());
 	ts_event->setPortRum(i->second->getRum());
+	ts_event->setRumPrice(i->second->getRumPrice());
 	
 	event_manager.queueEvent(ts_event);
       }

--- a/code/src/HumanGameView.cpp
+++ b/code/src/HumanGameView.cpp
@@ -8,7 +8,13 @@ HumanGameView::HumanGameView(GameLogic* game_logic, sf::RenderWindow* App) :
   GameView(game_logic),
   map_tl_wcoords(0, 0),
   map_tile_size(0),
-  App(App)
+  App(App),
+  tc_shipid(0),
+  tc_portid(0),
+  tc_shipgold(0),
+  tc_shiprum(0),
+  tc_portrum(0),
+  tc_rum_price(0)
 {
 	if (!texture.loadFromFile("./data/sprites.png")) {
 		std::cout << "ERROR TEXTURE" << std::endl;
@@ -283,7 +289,7 @@ void HumanGameView::drawUI() {
 // handles transaction fails
 void HumanGameView::transactionFailEventHandler(const EventInterface& event) {
 	std::ostringstream oss;
-	oss << "Incorrect Amount!\nSupply: " << tc_portrum << "\nPrice: " << (11 - tc_portrum);
+	oss << "Incorrect Amount!\nSupply: " << tc_portrum << "\nPrice: " << tc_rum_price;
 	test->setDialogue(oss.str());
 }
 
@@ -309,8 +315,9 @@ void HumanGameView::transactionStartEventHandler(const EventInterface& event) {
     tc_shipgold = ts_event->getShipGold();
     tc_shiprum = ts_event->getShipRum();
     tc_portrum = ts_event->getPortRum();
+    tc_rum_price = ts_event->getRumPrice();
 	std::ostringstream oss;
-	oss << "Supply: " << tc_portrum << "\nPrice: " << (11 - tc_portrum);
+	oss << "Supply: " << tc_portrum << "\nPrice: " << tc_rum_price;
 	test->setDialogue(oss.str());
 }
 

--- a/code/src/TransactionStartEvent.cpp
+++ b/code/src/TransactionStartEvent.cpp
@@ -13,17 +13,19 @@ TransactionStartEvent::TransactionStartEvent() :
   port_id(0),
   ship_gold(0),
   ship_rum(0),
-  port_rum(0)
+  port_rum(0),
+  rum_price(0)
 {
 }
 
-TransactionStartEvent::TransactionStartEvent(ActorId ship_id, ActorId port_id, double ship_gold, double ship_rum, double port_rum)
+TransactionStartEvent::TransactionStartEvent(ActorId ship_id, ActorId port_id, double ship_gold, double ship_rum, double port_rum, unsigned int rum_price)
   : EventInterface(),
     ship_id(ship_id),
     port_id(port_id),
     ship_gold(ship_gold),
     ship_rum(ship_rum),
-    port_rum(port_rum)
+    port_rum(port_rum),
+    rum_price(rum_price)
 {
 }
 


### PR DESCRIPTION
Fixed the transaction window price bug (issue #59).  The TransactionStartEvent now records what the rum price is at the port where the transaction is happening, and when the human game view handles TransactionStartEvents it stores this price in a new tc_rum_price variable.  This variable is referenced, instead of the original incorrect price calculation, for display in the transaction window.

No more "Price: 4326645743" or "Price: -1"!
