### PR TITLE
Gametimer fix

### DIFF
--- a/code/include/UIGameTime.hpp
+++ b/code/include/UIGameTime.hpp
@@ -3,6 +3,7 @@
 
 #include <SFML/Graphics.hpp>
 
+#include "ActorId.hpp"
 #include "UIElement.hpp"
 #include "UITextField.hpp"
 
@@ -20,61 +21,65 @@ public:
 
   virtual ~UIGameTime();
 
+  virtual void draw(sf::RenderWindow* window);
+
   virtual void initialize(sf::Vector2f s,
-                          sf::Vector2u curRes,
-                          Orientation orient);
+			  sf::Vector2u curRes,
+			  Orientation  orient);
 
   virtual void update(HumanGameView* hgv);
 
   virtual void resize(sf::Vector2u curRes);
 
-  virtual void draw(sf::RenderWindow* window);
-
 
   void setPosition(const sf::Vector2f& position);
 
+  const sf::Vector2f& getPosition() const;
+
   void setCharacterSize(unsigned int size);
 
-  void setGameTime(double game_time);
+  unsigned int getCharacterSize() const;
 
   void setColor(const sf::Color& color);
 
-  void setStyle(sf::Text::Style style);
+  void loadFontFromFile(const std::string& font);
+
+  void setMessage(const std::string& message);
+
+  void setTimer(int timer);
 
 private:
 
-  void updateText();
+  // Text field for displaying the timer's text
+  UITextField message_field;
 
-  // Displays ship data
-  UITextField text;
-
-  // Game time to be displayed
-  double game_time;
+  // Text field for displaying timer's amount
+  UITextField timer_field;
 };
 
-inline void UIGameTime::setPosition(const sf::Vector2f& position)
+inline const sf::Vector2f& UIGameTime::getPosition() const
 {
-  text.setPosition(position);
+  // The name field draws at the top-left of this UI element so its position is
+  // the position of the whole thing
+  return message_field.getPosition();
 }
 
-inline void UIGameTime::setCharacterSize(unsigned int size)
+inline unsigned int UIGameTime::getCharacterSize() const
 {
-  text.setCharacterSize(size);
-}
-
-inline void UIGameTime::setGameTime(double game_time)
-{
-  this->game_time = game_time;
+  // Both fields are supposed to be set to the same character size, so just
+  // return the size from one of them
+  return message_field.getCharacterSize();
 }
 
 inline void UIGameTime::setColor(const sf::Color& color)
 {
-  text.setColor(color);
+  message_field.setColor(color);
+  timer_field.setColor(color);
 }
 
-inline void UIGameTime::setStyle(sf::Text::Style style)
+inline void UIGameTime::setMessage(const std::string& message)
 {
-  text.setStyle(style);
+  message_field.setText(message);
 }
 
 #endif

--- a/code/src/UIGameTime.cpp
+++ b/code/src/UIGameTime.cpp
@@ -96,7 +96,9 @@ void UIGameTime::setTimer(int timer)
 {
   // Convert the given number into a string
   std::ostringstream num_to_str;
-  num_to_str << timer;
+  num_to_str << timer / 60;
+  num_to_str << ":";
+  num_to_str << timer % 60;
 
   timer_field.setText(num_to_str.str());
 }

--- a/code/src/UIGameTime.cpp
+++ b/code/src/UIGameTime.cpp
@@ -1,67 +1,102 @@
 #include <SFML/Graphics.hpp>
+#include <iostream>
 #include <sstream>
+#include <string>
 
+#include "ActorId.hpp"
+#include "GameLogic.hpp"
 #include "HumanGameView.hpp"
 #include "UIGameTime.hpp"
 
 UIGameTime::UIGameTime() :
   UIElement()
 {
-  // Defaults
-  setPosition(sf::Vector2f(600, 0));
+  // timer data displayed in black
   setColor(sf::Color::White);
-  setStyle(sf::Text::Bold);
+
+  // timer data initially displayed in 10 pixel size
+  setCharacterSize(10);
+
+  // Defaults
+  setMessage("Time Until Loan Shark: ");
+  setTimer(0.0);
+
+  // both fields are always bold
+  message_field.setStyle(sf::Text::Bold);
+  timer_field.setStyle(sf::Text::Bold);
 }
 
 UIGameTime::~UIGameTime()
 {
 }
 
+void UIGameTime::draw(sf::RenderWindow* window)
+{
+  message_field.draw(window);
+  timer_field.draw(window);
+}
+
 void UIGameTime::initialize(sf::Vector2f s,
-                            sf::Vector2u curRes,
-                            Orientation  orient)
+			    sf::Vector2u curRes,
+			    Orientation  orient)
 {
 }
 
 void UIGameTime::update(HumanGameView* hgv)
 {
-  // Adjust for prettiness
-  setCharacterSize(static_cast<double>(hgv->getMapTileSize()) * 0.75);
+  // Grab a convenience pointer back to the port we're interested in
+  setTimer(hgv->getGameLogic()->getGameTime());
+  setCharacterSize(hgv->getMapTileSize() / 1.5);
 
-  setGameTime(hgv->getGameLogic()->getGameTime());
+  // Convert port position into vector
+  sf::Vector2f map_position(22, 0);
 
-  updateText();
+  sf::Vector2f window_position;
+  hgv->mapToWindow(map_position, window_position);
+
+  setPosition(window_position);
 }
 
 void UIGameTime::resize(sf::Vector2u curRes)
 {
 }
 
-void UIGameTime::draw(sf::RenderWindow* window)
+void UIGameTime::setPosition(const sf::Vector2f& position)
 {
-  text.draw(window);
+  message_field.setPosition(position);
+  
+  sf::Vector2f new_field_position = message_field.getPosition();
+  new_field_position.x += 12 * getCharacterSize();
+  timer_field.setPosition(new_field_position);
 }
 
-void UIGameTime::updateText()
+void UIGameTime::setCharacterSize(unsigned int size)
 {
-  // Will hold the text as it is formed
-  std::string updated_text;
+  // First off just set the field character sizes
+  message_field.setCharacterSize(size);
+  timer_field.setCharacterSize(size);
 
-  // Convert game time into minutes and seconds
-  unsigned int minutes = (game_time) / 60;
-  unsigned int seconds = (int) (game_time) % 60;
+  setPosition(getPosition());
+}
 
-  // Convert game time into text
-  std::ostringstream min_to_str;
-  min_to_str << minutes;
-  std::ostringstream sec_to_str;
-  sec_to_str << seconds;
-  if (seconds < 10) {
-    updated_text = "Time remaining " + min_to_str.str() + ":0" + sec_to_str.str();
+void UIGameTime::loadFontFromFile(const std::string& font)
+{
+  if (!message_field.loadFontFromFile(font))
+  {
+    std::cerr << "Couldn't load UIGameTime message font\n";
   }
-  else {
-    updated_text = "Time remaining " + min_to_str.str() + ":" + sec_to_str.str();
+
+  if (!timer_field.loadFontFromFile(font))
+  {
+    std::cerr << "Couldn't load UIGameTime timer font\n";
   }
-  
-  text.setText(updated_text);
+}
+
+void UIGameTime::setTimer(int timer)
+{
+  // Convert the given number into a string
+  std::ostringstream num_to_str;
+  num_to_str << timer;
+
+  timer_field.setText(num_to_str.str());
 }


### PR DESCRIPTION
Now properly scales and repositions when displaying time.  I noticed when I was making this that the ship data doesn't position properly, it will sit in blank space if you make the window right.  I couldn't figure out why when I was giving it a look though.
